### PR TITLE
feature(user) : UUID 전환, 스웨거 문서 항목 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -37,6 +37,8 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
     implementation 'me.paulschwarz:spring-dotenv:4.0.0'
+    // 아래는 커밋 전에 지우기
+    implementation("org.mindrot:jbcrypt:0.4")
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/backend/domain/user/user/controller/UserController.java
+++ b/backend/src/main/java/com/backend/domain/user/user/controller/UserController.java
@@ -25,7 +25,7 @@ import java.util.UUID;
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
 @RestController
-@Tag(name = "UserController", description = "")
+@Tag(name = "User", description = "회원 API")
 public class UserController {
 
     private final UserService userService;
@@ -46,7 +46,8 @@ public class UserController {
     ) {}
 
     @PostMapping("/join")
-    public ResponseEntity<ApiResponse> Join(
+    @Operation(summary = "회원 가입", description = "새로운 회원을 등록합니다.")
+    public ResponseEntity<ApiResponse> join(
             @Valid @RequestBody UserController.UserJoinReqBody form,
             BindingResult bindingResult
     ) throws Exception {
@@ -80,7 +81,8 @@ public class UserController {
     {}
 
     @GetMapping("/login")
-    public ResponseEntity<ApiResponse> Login(
+    @Operation(summary = "회원 로그인", description = "사용자의 정보를 확인하고 ApiKey를 클라이언트에 전송합니다.")
+    public ResponseEntity<ApiResponse> login(
             @Valid @RequestBody UserLoginReqBody reqBody,
             BindingResult bindingResult
     ) throws Exception {
@@ -100,7 +102,7 @@ public class UserController {
         }
 
         UserDto userDto = userService.login(reqBody.email,reqBody.password);
-        Cookie cookie = new Cookie("userId", userDto.userId()+"");
+        Cookie cookie = new Cookie("apiKey", userDto.apiKey());
         cookie.setMaxAge(3600);
         cookie.setPath("/");
         cookie.setHttpOnly(true);
@@ -110,8 +112,9 @@ public class UserController {
     }
 
     @GetMapping("/logout")
-    public ResponseEntity<ApiResponse> Logout(){
-        Cookie cookie = new Cookie("userId", null);
+    @Operation(summary = "회원 로그아웃", description = "현재 로그인 된 회원의 정보를 클라이언트에서 제거 하여 로그아웃 시킵니다.")
+    public ResponseEntity<ApiResponse> logout(){
+        Cookie cookie = new Cookie("apiKey", null);
         cookie.setMaxAge(0);
         cookie.setPath("/");
         cookie.setHttpOnly(true);

--- a/backend/src/main/java/com/backend/domain/user/user/dto/UserDto.java
+++ b/backend/src/main/java/com/backend/domain/user/user/dto/UserDto.java
@@ -7,22 +7,22 @@ import java.time.LocalDateTime;
 public record UserDto (
         Long userId,
         String userEmail,
-        String password,
         String phoneNumber,
         LocalDateTime createDate,
         LocalDateTime modifyDate,
-        int level
+        int level,
+        String apiKey
 ) {
 
     public UserDto(Users users){
         this(
                 users.getUserId(),
                 users.getEmail(),
-                users.getPassword(),
                 users.getPhoneNumber(),
                 users.getCreateDate(), // base Entity 도입시 해당 부분으로 객체 적용.
                 users.getModifyDate(),
-                users.getLevel()
+                users.getLevel(),
+                users.getApiKey()
         );
     }
 }

--- a/backend/src/main/java/com/backend/domain/user/user/entity/Users.java
+++ b/backend/src/main/java/com/backend/domain/user/user/entity/Users.java
@@ -4,11 +4,15 @@ import com.backend.global.jpa.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.mindrot.jbcrypt.BCrypt;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Entity
 @Getter
+
 @NoArgsConstructor
 public class Users extends BaseEntity {
     @Id
@@ -21,12 +25,20 @@ public class Users extends BaseEntity {
     @Column(length = 15, nullable = false)
     private String phoneNumber;
     private int level;
+    private String apiKey;
 
     public Users(String email, String password, String phoneNumber, int level) {
         this.email = email;
         this.password = password;
         this.phoneNumber = phoneNumber;
         this.level = level;
+        this.apiKey = UUID.randomUUID().toString();
+    }
+
+    public String changeApiKey() throws Exception {
+        String newApiKey = UUID.randomUUID().toString();
+        this.apiKey = newApiKey;
+        return newApiKey;
     }
 
     public boolean isMatchedPassword(String password) {

--- a/backend/src/main/java/com/backend/domain/user/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/backend/domain/user/user/repository/UserRepository.java
@@ -7,6 +7,6 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<Users, Long> {
     Optional<Users> getUsersByEmail(String email);
-
+    Optional<Users> getUserByApiKey(String apikey);
     Optional<Users> getUsersByUserId(Long userId);
 }

--- a/backend/src/main/java/com/backend/domain/user/user/service/UserService.java
+++ b/backend/src/main/java/com/backend/domain/user/user/service/UserService.java
@@ -45,11 +45,27 @@ public class UserService {
     }
 
     public UserDto getUserByUserId(Long userId) throws Exception {
-        Optional<Users> optionalUsers = userRepository.getUsersByUserId(userId);
+        Optional<Users> optionalUser = userRepository.getUsersByUserId(userId);
+        if(!optionalUser.isPresent()){
+            throw new Exception("User not found");
+        }
+
+        return new UserDto(optionalUser.get());
+    }
+
+    public UserDto getUserByApiKey(String apikey) throws Exception {
+        Optional<Users> optionalUsers = userRepository.getUserByApiKey(apikey);
         if(!optionalUsers.isPresent()){
             throw new Exception("User not found");
         }
 
         return new UserDto(optionalUsers.get());
     }
+
+    public String changeApiKey(Users user) throws Exception {
+        String newApiKey = user.changeApiKey();
+        userRepository.save(user);
+        return newApiKey;
+    }
+
 }


### PR DESCRIPTION
## #️⃣ fixes  #41

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- 로그인 후 인가에 사용되는 정보를 UUID로 바꾸었습니다.
- 유저 컨트롤러 항목에 해당하는 부분에 스웨거 설명을 더하였습니다

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- 로그인 후 저장되는 정보 : userId -> apiKey
- api 문서화 작업

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
```java
new Cookie("apiKey", userDto.apiKey());
```
이렇게 쿠키가 저장됩니다.

```java
  @GetMapping("/login")
    @Operation(summary = "회원 로그인", description = "사용자의 정보를 확인하고 ApiKey를 클라이언트에 전송합니다.")
    public ResponseEntity<ApiResponse> login(
   ...

    @GetMapping("/logout")
    @Operation(summary = "회원 로그아웃", description = "현재 로그인 된 회원의 정보를 클라이언트에서 제거 하여 로그아웃 시킵니다.")
    public ResponseEntity<ApiResponse> logout(

```
위 느낌으로 작성하면 되겠지요?