### PR TITLE
feat: 메뉴 조회 기능 추가

### DIFF
--- a/backend/src/main/java/com/backend/domain/menu/controller/MenuController.java
+++ b/backend/src/main/java/com/backend/domain/menu/controller/MenuController.java
@@ -1,13 +1,39 @@
 package com.backend.domain.menu.controller;
 
+import com.backend.domain.menu.dto.MenuAddRequest;
+import com.backend.domain.menu.dto.MenuResponse;
+import com.backend.domain.menu.service.MenuService;
+import com.backend.domain.user.user.entity.Users;
+import com.backend.domain.user.user.repository.UserRepository;
+import com.backend.domain.user.user.service.UserService;
+import com.backend.global.exception.BusinessException;
+import com.backend.global.response.ApiResponse;
+import com.backend.global.response.ErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
-@RequestMapping("/api/menus")
 @RequiredArgsConstructor
-@Controller
-@Tag(name = "Controller 이름", description = "Controller 설명")
+@RestController
+@Tag(name = "MenuController", description = "메뉴 조회 및 관리자 메뉴 API")
 public class MenuController {
+
+    private final MenuService menuService;
+    private final UserRepository userRepository;
+
+    // ============ 관리자 ============
+
+    @PostMapping("/api/admin/menu")
+    @Operation(summary = "메뉴 생성", description = "새로운 메뉴를 생성합니다. (관리자 전용)")
+    public ResponseEntity<ApiResponse<MenuResponse>> createMenu(
+            @Valid @RequestBody MenuAddRequest request) {
+        // TODO: 메뉴 생성 로직 구현
+
+        MenuResponse response = menuService.createMenu(request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
 }

--- a/backend/src/main/java/com/backend/domain/menu/controller/MenuController.java
+++ b/backend/src/main/java/com/backend/domain/menu/controller/MenuController.java
@@ -17,6 +17,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RequiredArgsConstructor
 @RestController
 @Tag(name = "MenuController", description = "메뉴 조회 및 관리자 메뉴 API")
@@ -24,6 +26,14 @@ public class MenuController {
 
     private final MenuService menuService;
     private final UserRepository userRepository;
+
+    // =========== 사용자 ============
+
+    @GetMapping("/api/menu")
+    @Operation(summary = "메뉴 조회", description = "전체 메뉴(품절 제외)를 조회합니다. (사용자 전용)")
+    public ResponseEntity<ApiResponse<List<MenuResponse>>> getAllMenus() {
+        return ResponseEntity.ok(menuService.getAllMenu());
+    }
 
     // ============ 관리자 ============
 
@@ -35,5 +45,11 @@ public class MenuController {
 
         MenuResponse response = menuService.createMenu(request);
         return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/api/admin/menu")
+    @Operation(summary = "메뉴 조회 (관리자)", description = "품절 여부와 상관없이 전체 메뉴를 조회합니다.")
+    public ResponseEntity<ApiResponse<List<MenuResponse>>> getAllMenusForAdmin() {
+        return ResponseEntity.ok(menuService.getAllMenuForAdmin());
     }
 }

--- a/backend/src/main/java/com/backend/domain/menu/dto/MenuAddRequest.java
+++ b/backend/src/main/java/com/backend/domain/menu/dto/MenuAddRequest.java
@@ -7,20 +7,23 @@ import jakarta.validation.constraints.Positive;
 
 public record MenuAddRequest(
         @NotBlank(message = "메뉴 이름은 필수입니다.")
-        @Schema(description = "메뉴 이름", example = "아메리카노")
+        @Schema(description = "메뉴 이름", example = "콜롬비아 수프리모")
         String name,
 
         @Schema(description = "가격", example = "25000")
         @Positive(message = "가격은 0보다 커야 합니다.")
         int price,
 
-        @Schema(description = "설명", example = "진한 에스프레소와 물")
-        String description,
+        @Schema(description = "품절 여부", example = "false")
+        Boolean isSoldOut,
 
+        @Schema(description = "설명", example = "균형잡힌 맛과 부드러운 바디감")
+        String description,
 
         @Pattern(
                 regexp = "^(https?://).+",
                 message = "이미지 URL은 http:// 또는 https://로 시작해야 합니다."
         )
         String imageUrl
-) {}
+) {
+}

--- a/backend/src/main/java/com/backend/domain/menu/dto/MenuAddRequest.java
+++ b/backend/src/main/java/com/backend/domain/menu/dto/MenuAddRequest.java
@@ -1,0 +1,26 @@
+package com.backend.domain.menu.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
+
+public record MenuAddRequest(
+        @NotBlank(message = "메뉴 이름은 필수입니다.")
+        @Schema(description = "메뉴 이름", example = "아메리카노")
+        String name,
+
+        @Schema(description = "가격", example = "25000")
+        @Positive(message = "가격은 0보다 커야 합니다.")
+        int price,
+
+        @Schema(description = "설명", example = "진한 에스프레소와 물")
+        String description,
+
+
+        @Pattern(
+                regexp = "^(https?://).+",
+                message = "이미지 URL은 http:// 또는 https://로 시작해야 합니다."
+        )
+        String imageUrl
+) {}

--- a/backend/src/main/java/com/backend/domain/menu/dto/MenuResponse.java
+++ b/backend/src/main/java/com/backend/domain/menu/dto/MenuResponse.java
@@ -1,0 +1,23 @@
+package com.backend.domain.menu.dto;
+
+import com.backend.domain.menu.entity.Menu;
+
+public record MenuResponse(
+        Long menuId,
+        String name,
+        int price,
+        Boolean isSoldOut,
+        String description,
+        String imageUrl
+) {
+    public static MenuResponse from(Menu menu) {
+        return new MenuResponse(
+                menu.getMenuId(),
+                menu.getName(),
+                menu.getPrice(),
+                menu.getIsSoldOut(),
+                menu.getDescription(),
+                menu.getImageUrl()
+        );
+    }
+}

--- a/backend/src/main/java/com/backend/domain/menu/entity/Menu.java
+++ b/backend/src/main/java/com/backend/domain/menu/entity/Menu.java
@@ -31,9 +31,10 @@ public class Menu extends BaseEntity {
     @Column(length = 255)
     private String imageUrl;    // 메뉴 이미지 URL
 
-    public Menu(String name, int price, String description, String imageUrl) {
+    public Menu(String name, int price, Boolean isSoldOut, String description, String imageUrl) {
         this.name = name;
         this.price = price;
+        this.isSoldOut = isSoldOut != null ? isSoldOut : false;
         this.description = description;
         this.imageUrl = imageUrl;
     }

--- a/backend/src/main/java/com/backend/domain/menu/entity/Menu.java
+++ b/backend/src/main/java/com/backend/domain/menu/entity/Menu.java
@@ -1,18 +1,15 @@
 package com.backend.domain.menu.entity;
 
+import com.backend.global.jpa.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "menu")
 @Getter
 @NoArgsConstructor
-public class Menu {
+public class Menu extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -26,7 +23,7 @@ public class Menu {
     private int price;    // 메뉴 가격
 
     @Column(nullable = false)
-    private Boolean isSoldOut;  // 품절 여부
+    private Boolean isSoldOut = false;  // 품절 여부
 
     @Column(columnDefinition = "TEXT")
     private String description; // 메뉴 설명
@@ -34,18 +31,9 @@ public class Menu {
     @Column(length = 255)
     private String imageUrl;    // 메뉴 이미지 URL
 
-    @CreationTimestamp
-    @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt;  // 생성 시간
-
-    @UpdateTimestamp
-    @Column(nullable = false)
-    private LocalDateTime updatedAt;  // 수정 시간
-
-    public Menu(String name, int price, Boolean isSoldOut, String description, String imageUrl) {
+    public Menu(String name, int price, String description, String imageUrl) {
         this.name = name;
         this.price = price;
-        this.isSoldOut = isSoldOut;
         this.description = description;
         this.imageUrl = imageUrl;
     }

--- a/backend/src/main/java/com/backend/domain/menu/repository/MenuRepository.java
+++ b/backend/src/main/java/com/backend/domain/menu/repository/MenuRepository.java
@@ -3,5 +3,6 @@ package com.backend.domain.menu.repository;
 import com.backend.domain.menu.entity.Menu;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MenuRepository extends JpaRepository<Menu, Integer> {
+public interface MenuRepository extends JpaRepository<Menu, Long> {
+    boolean existsByName(String name);
 }

--- a/backend/src/main/java/com/backend/domain/menu/repository/MenuRepository.java
+++ b/backend/src/main/java/com/backend/domain/menu/repository/MenuRepository.java
@@ -3,6 +3,11 @@ package com.backend.domain.menu.repository;
 import com.backend.domain.menu.entity.Menu;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MenuRepository extends JpaRepository<Menu, Long> {
     boolean existsByName(String name);
+
+    // 품절이 아닌 메뉴만 조회
+    List<Menu> findByIsSoldOutFalse();
 }

--- a/backend/src/main/java/com/backend/domain/menu/service/MenuService.java
+++ b/backend/src/main/java/com/backend/domain/menu/service/MenuService.java
@@ -5,15 +5,31 @@ import com.backend.domain.menu.dto.MenuResponse;
 import com.backend.domain.menu.entity.Menu;
 import com.backend.domain.menu.repository.MenuRepository;
 import com.backend.global.exception.BusinessException;
+import com.backend.global.response.ApiResponse;
 import com.backend.global.response.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @Service
 public class MenuService {
 
     private final MenuRepository menuRepository;
+
+    // =========== 사용자 ============
+
+    // 전체 메뉴 조회(사용자)
+    public ApiResponse<List<MenuResponse>> getAllMenu() {
+        List<MenuResponse> menus = menuRepository.findByIsSoldOutFalse().stream()
+                .map(MenuResponse::from)
+                .toList();
+
+        return ApiResponse.success(menus);
+    }
+
+    // ============ 관리자 ============
 
     // 메뉴 생성 (관리자)
     public MenuResponse createMenu(MenuAddRequest request) {
@@ -24,7 +40,6 @@ public class MenuService {
 //        }
 
         // 메뉴 이름 중복 체크
-        // 예외 처리 핸들러 추가 되면 변경 필요
         if (menuRepository.existsByName(request.name())) {
             throw new BusinessException(ErrorCode.DUPLICATE_MENU_NAME);
         }
@@ -32,6 +47,7 @@ public class MenuService {
         Menu menu = new Menu(
                 request.name(),
                 request.price(),
+                request.isSoldOut(),
                 request.description(),
                 request.imageUrl()
         );
@@ -39,4 +55,12 @@ public class MenuService {
         return MenuResponse.from(menuRepository.save(menu));
     }
 
+    // 관리자 전용 조회 (품절 포함)
+    public ApiResponse<List<MenuResponse>> getAllMenuForAdmin() {
+        List<MenuResponse> menus = menuRepository.findAll().stream()
+                .map(MenuResponse::from)
+                .toList();
+
+        return ApiResponse.success(menus);
+    }
 }

--- a/backend/src/main/java/com/backend/domain/menu/service/MenuService.java
+++ b/backend/src/main/java/com/backend/domain/menu/service/MenuService.java
@@ -1,9 +1,42 @@
 package com.backend.domain.menu.service;
 
+import com.backend.domain.menu.dto.MenuAddRequest;
+import com.backend.domain.menu.dto.MenuResponse;
+import com.backend.domain.menu.entity.Menu;
+import com.backend.domain.menu.repository.MenuRepository;
+import com.backend.global.exception.BusinessException;
+import com.backend.global.response.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
 @Service
 public class MenuService {
+
+    private final MenuRepository menuRepository;
+
+    // 메뉴 생성 (관리자)
+    public MenuResponse createMenu(MenuAddRequest request) {
+
+        // 관리자 권한 체크
+//        if (user.getLevel() != 1) { // 예: 1 = 관리자
+//            throw new BusinessException(ErrorCode.FORBIDDEN_ADMIN);
+//        }
+
+        // 메뉴 이름 중복 체크
+        // 예외 처리 핸들러 추가 되면 변경 필요
+        if (menuRepository.existsByName(request.name())) {
+            throw new BusinessException(ErrorCode.DUPLICATE_MENU_NAME);
+        }
+
+        Menu menu = new Menu(
+                request.name(),
+                request.price(),
+                request.description(),
+                request.imageUrl()
+        );
+
+        return MenuResponse.from(menuRepository.save(menu));
+    }
+
 }

--- a/backend/src/main/java/com/backend/global/response/ErrorCode.java
+++ b/backend/src/main/java/com/backend/global/response/ErrorCode.java
@@ -22,7 +22,19 @@ public enum ErrorCode {
     // 수량을 0 이하의 값으로 변경하려고 할 때 발생시킵니다.
     INVALID_QUANTITY("C004", HttpStatus.BAD_REQUEST, "상품 수량은 1개 이상이어야 합니다."),
     // 장바구니가 비어있는 상태에서 주문 시도할 때 발생시킵니다.
-    EMPTY_CART("C006", HttpStatus.NOT_FOUND, "장바구니가 비어 있습니다.");
+    EMPTY_CART("C006", HttpStatus.NOT_FOUND, "장바구니가 비어 있습니다."),
+
+    // 메뉴
+    // 이름이 중복되는 메뉴를 생성하려고 할 때 발생시킵니다.
+    DUPLICATE_MENU_NAME("M001", HttpStatus.CONFLICT, "이미 존재하는 메뉴 이름입니다."),
+    // 메뉴 ID가 DB에 존재하지 않을 때 사용합니다.
+    NOT_FOUND_MENU("M002", HttpStatus.NOT_FOUND, "존재하지 않는 메뉴입니다."),
+    // 관리자 권한이 없는 사용자가 관리자 전용 기능을 사용하려고 할 때 발생시킵니다.
+    FORBIDDEN_ADMIN("M003", HttpStatus.FORBIDDEN, "관리자 권한이 필요합니다."),
+    // 메뉴가 품절 상태일 때 발생시킵니다.
+    MENU_SOLD_OUT("M004", HttpStatus.CONFLICT, "품절된 메뉴입니다."),
+    // 메뉴 가격이 음수일 때 발생시킵니다.
+    INVALID_MENU_PRICE("M005", HttpStatus.BAD_REQUEST, "메뉴 가격은 음수일 수 없습니다.");
 
     private final String code;
     private final HttpStatus status;


### PR DESCRIPTION
## #️⃣ 연관된 이슈 <!-- 이슈 번호를 적어주세요 -->

#42

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->

사용자가 메뉴를 조회할 수 있는 메뉴 조회 API를 구현했습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

메뉴 조회 API 엔드포인트 구현

사용자 조회
GET /api/menu

관리자 조회
GET /api/admin/menu

응답 DTO(MenuResponse) 리스트 반환

DB 조회 로직

MenuRepository.findAll()을 통해 메뉴 목록 조회

응답 반환

성공 시 200 OK

메뉴 리스트를 MenuResponse DTO로 변환 후 반환

### [관리자 조회 기능] 품절 포함 메뉴 조회

<img width="1650" height="901" alt="image" src="https://github.com/user-attachments/assets/271c6982-41c9-4a26-ac09-74e46fabc583" />


### [사용자 조회 기능] 품절 제외 메뉴 조회
<img width="1640" height="800" alt="image" src="https://github.com/user-attachments/assets/f0ea31a3-3b38-4f27-a9d3-1729b5fc013c" />

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
