### PR TITLE
feature: 사용자 주문 조회 기능 추가

### DIFF
--- a/backend/src/main/java/com/backend/domain/order/controller/OrderController.java
+++ b/backend/src/main/java/com/backend/domain/order/controller/OrderController.java
@@ -10,7 +10,10 @@ import com.backend.domain.order.service.OrderService;
 import com.backend.domain.user.address.entity.Address;
 import com.backend.domain.user.address.repository.AddressRepository;
 import com.backend.domain.user.address.service.AddressService;
+import com.backend.domain.user.user.entity.Users;
+import com.backend.domain.user.user.service.UserService;
 import com.backend.global.response.ApiResponse;
+import com.backend.global.rq.Rq;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -31,6 +34,7 @@ import java.util.Optional;
 public class OrderController {
 
     private final OrderService orderService;
+    private final Rq rq;
 
     @PostMapping
     @Transactional
@@ -38,7 +42,10 @@ public class OrderController {
     public ResponseEntity<ApiResponse<OrderCreateResponse>> createOrder(
             @Valid @RequestBody OrderCreateRequest request
     ) throws Exception {
-        Orders order = orderService.createOrder(request);
+
+        Users actor = rq.getUser();
+        Orders order = orderService.createOrder(actor, request);
+
         return ResponseEntity.ok(ApiResponse.success(new OrderCreateResponse((order))));
     }
 
@@ -59,11 +66,11 @@ public class OrderController {
 
     @GetMapping
     @Operation(summary = "사용자 주문 목록 조회")
-    public ResponseEntity<ApiResponse<List<OrderSummaryResponse>>> getOrders(
-            @RequestParam Long userId
-    ) {
+    public ResponseEntity<ApiResponse<List<OrderSummaryResponse>>> getOrders() {
+        //쿠키에서 인증된 유저 가져오기
+        Users actor = rq.getUser();
         //주문 조회 로직
-        List<OrderSummaryResponse> summaries = orderService.getOrdersByUserId(userId);
+        List<OrderSummaryResponse> summaries = orderService.getOrdersByUserId(actor.getUserId());
         return ResponseEntity.ok(ApiResponse.success(summaries));
     }
 }

--- a/backend/src/main/java/com/backend/domain/order/controller/OrderController.java
+++ b/backend/src/main/java/com/backend/domain/order/controller/OrderController.java
@@ -3,13 +3,17 @@ package com.backend.domain.order.controller;
 import com.backend.domain.order.dto.request.OrderCreateRequest;
 import com.backend.domain.order.dto.request.OrderStatusUpdateRequest;
 import com.backend.domain.order.dto.response.OrderCreateResponse;
+import com.backend.domain.order.dto.response.OrderSummaryDetailResponse;
+import com.backend.domain.order.dto.response.OrderSummaryResponse;
 import com.backend.domain.order.entity.Orders;
 import com.backend.domain.order.service.OrderService;
+import com.backend.domain.user.address.entity.Address;
+import com.backend.domain.user.address.repository.AddressRepository;
+import com.backend.domain.user.address.service.AddressService;
 import com.backend.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -44,7 +48,6 @@ public class OrderController {
     public ResponseEntity<ApiResponse<OrderCreateResponse>> updateOrderStatus(
             @PathVariable Long orderId,
             @RequestBody @Valid OrderStatusUpdateRequest reqBody
-
     ) {
         // 주문 상태 업데이트 로직 (예: 결제 완료, 배송 중 등)
         orderService.updateOrderStatus(orderId, reqBody.newStatus());
@@ -54,31 +57,13 @@ public class OrderController {
         return ResponseEntity.ok(ApiResponse.success(new OrderCreateResponse(updatedOrder)));
     }
 
-    public record OrderSummaryResponse(
-            Long orderId,
-            String status,
-            int orderAmount,
-            LocalDateTime orderTime
-    ) {
-    }
-
     @GetMapping
     @Operation(summary = "사용자 주문 목록 조회")
     public ResponseEntity<ApiResponse<List<OrderSummaryResponse>>> getOrders(
             @RequestParam Long userId
     ) {
-        List<Orders> orders = orderService.getOrdersByUserId(userId);
-
-        // Orders → OrderSummaryResponse 변환
-        List<OrderSummaryResponse> summaries = orders.stream()
-                .map(order -> new OrderSummaryResponse(
-                        order.getOrderId(),
-                        order.getOrderStatus().name(),
-                        order.getOrderAmount(),
-                        order.getCreateDate()
-                ))
-                .toList();
-
+        //주문 조회 로직
+        List<OrderSummaryResponse> summaries = orderService.getOrdersByUserId(userId);
         return ResponseEntity.ok(ApiResponse.success(summaries));
     }
 }

--- a/backend/src/main/java/com/backend/domain/order/controller/OrderController.java
+++ b/backend/src/main/java/com/backend/domain/order/controller/OrderController.java
@@ -28,7 +28,6 @@ public class OrderController {
 
     private final OrderService orderService;
 
-
     @PostMapping
     @Transactional
     @Operation(summary = "주문 생성")

--- a/backend/src/main/java/com/backend/domain/order/dto/request/OrderCreateRequest.java
+++ b/backend/src/main/java/com/backend/domain/order/dto/request/OrderCreateRequest.java
@@ -6,7 +6,6 @@ import java.util.List;
 
 // 주문 생성 시 요청 DTO
 public record OrderCreateRequest(
-        @Email String email,
         @Min(0) int amount,
         @NotEmpty List<OrderDetailsCreateRequest> items
 ) {

--- a/backend/src/main/java/com/backend/domain/order/dto/request/OrderCreateRequest.java
+++ b/backend/src/main/java/com/backend/domain/order/dto/request/OrderCreateRequest.java
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.*;
 
 import java.util.List;
 
-// 주문 상세 요청 DTO
+// 주문 생성 시 요청 DTO
 public record OrderCreateRequest(
         @Email String email,
         @Min(0) int amount,

--- a/backend/src/main/java/com/backend/domain/order/dto/request/OrderDetailsCreateRequest.java
+++ b/backend/src/main/java/com/backend/domain/order/dto/request/OrderDetailsCreateRequest.java
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
-// 주문 상세 요청 DTO
+// 주문 생성시 상세 요청 DTO
 public record OrderDetailsCreateRequest(
         @NotNull Long productId,
         @NotBlank String menuName,

--- a/backend/src/main/java/com/backend/domain/order/dto/response/OrderSummaryDetailResponse.java
+++ b/backend/src/main/java/com/backend/domain/order/dto/response/OrderSummaryDetailResponse.java
@@ -1,0 +1,7 @@
+package com.backend.domain.order.dto.response;
+
+public record OrderSummaryDetailResponse(
+        String productName,   // 상품명
+        int quantity,         // 상품 개수
+        int orderPrice        // 결제 금액 (해당 상품 총 금액)
+) { }

--- a/backend/src/main/java/com/backend/domain/order/dto/response/OrderSummaryResponse.java
+++ b/backend/src/main/java/com/backend/domain/order/dto/response/OrderSummaryResponse.java
@@ -1,0 +1,13 @@
+package com.backend.domain.order.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record OrderSummaryResponse(
+        Long orderId,              // 주문 번호
+        LocalDateTime orderTime,   // 주문 일시
+        int orderAmount,           // 총 금액
+        String status,             // 주문 상태
+//        String address,            // 주소 (Address 엔티티의 필드 합쳐서 String 처리)
+        List<OrderSummaryDetailResponse> items  // 주문 상세 목록
+) {}

--- a/backend/src/main/java/com/backend/domain/order/repository/OrderRepository.java
+++ b/backend/src/main/java/com/backend/domain/order/repository/OrderRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface OrderRepository extends JpaRepository<Orders, Long> {
-    List<Orders> findByUserUserId(Long userId);
+    List<Orders> findByUser_UserId(Long userId);
 }

--- a/backend/src/main/java/com/backend/domain/order/service/OrderService.java
+++ b/backend/src/main/java/com/backend/domain/order/service/OrderService.java
@@ -35,8 +35,9 @@ public class OrderService {
 
     @Transactional
     public Orders createOrder(Users actor, OrderCreateRequest request) throws Exception {
-        // 1. 유저는 이미 Rq에서 검증
-        Users user = actor;
+        // 1. 유저가 존재하는지 검증
+        Users user = usersRepository.findById(actor.getUserId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_MEMBER));
 
         // 2. 주문 항목 처리
         List<OrderDetails> orderDetails = new ArrayList<>();

--- a/backend/src/main/java/com/backend/domain/order/service/OrderService.java
+++ b/backend/src/main/java/com/backend/domain/order/service/OrderService.java
@@ -75,8 +75,6 @@ public class OrderService {
         return orderRepository.save(order);
     }
 
-
-
     @Transactional
     public void updateOrderStatus(Long orderId, String status) {
         // 1. 주문 존재 확인
@@ -116,6 +114,6 @@ public class OrderService {
     }
 
     public List<Orders> getOrdersByUserId(Long userId) {
-        return orderRepository.findByUserUserId(userId);
+        return orderRepository.findByUser_UserId(userId);
     }
 }

--- a/backend/src/main/java/com/backend/domain/order/service/OrderService.java
+++ b/backend/src/main/java/com/backend/domain/order/service/OrderService.java
@@ -2,7 +2,6 @@ package com.backend.domain.order.service;
 
 import com.backend.domain.menu.entity.Menu;
 import com.backend.domain.menu.repository.MenuRepository;
-import com.backend.domain.order.controller.OrderController;
 import com.backend.domain.order.dto.request.OrderCreateRequest;
 import com.backend.domain.order.dto.request.OrderDetailsCreateRequest;
 import com.backend.domain.order.dto.response.OrderSummaryDetailResponse;
@@ -11,13 +10,11 @@ import com.backend.domain.order.entity.OrderDetails;
 import com.backend.domain.order.entity.OrderStatus;
 import com.backend.domain.order.entity.Orders;
 import com.backend.domain.order.repository.OrderRepository;
-import com.backend.domain.user.user.dto.UserDto;
 import com.backend.domain.user.user.entity.Users;
 import com.backend.domain.user.user.repository.UserRepository;
 import com.backend.domain.user.user.service.UserService;
 import com.backend.global.exception.BusinessException;
 import com.backend.global.response.ErrorCode;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,10 +34,10 @@ public class OrderService {
     private final UserService usersService;
 
     @Transactional
-    public Orders createOrder(@Valid OrderCreateRequest request) throws Exception {
-        // 1. 유저 확인 (Users 엔티티 직접 조회)
-        Users user = (usersRepository.getUsersByEmail(request.email())
-                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_MEMBER)));
+    public Orders createOrder(Users actor, OrderCreateRequest request) throws Exception {
+        // 1. 유저는 이미 Rq에서 검증
+        Users user = actor;
+
         // 2. 주문 항목 처리
         List<OrderDetails> orderDetails = new ArrayList<>();
         int calculatedTotal = 0;
@@ -115,6 +112,7 @@ public class OrderService {
         return orderRepository.findById(orderId);
     }
 
+    // 사용자 ID로 주문 목록 조회
     @Transactional(readOnly = true)
     public List<OrderSummaryResponse> getOrdersByUserId(Long userId) {
         List<Orders> orders = orderRepository.findByUser_UserId(userId);

--- a/backend/src/main/java/com/backend/domain/order/service/OrderService.java
+++ b/backend/src/main/java/com/backend/domain/order/service/OrderService.java
@@ -115,7 +115,16 @@ public class OrderService {
     // 사용자 ID로 주문 목록 조회
     @Transactional(readOnly = true)
     public List<OrderSummaryResponse> getOrdersByUserId(Long userId) {
+        // 1. 사용자 존재 확인
+        Users user = usersRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_MEMBER));
+
+        // 2. 주문 목록 조회
         List<Orders> orders = orderRepository.findByUser_UserId(userId);
+
+        if (orders.isEmpty()) {
+            throw new BusinessException(ErrorCode.NOT_FOUND_ORDER);
+        }
 
         return orders.stream()
                 .map(order -> new OrderSummaryResponse(

--- a/backend/src/main/java/com/backend/domain/order/service/OrderService.java
+++ b/backend/src/main/java/com/backend/domain/order/service/OrderService.java
@@ -5,6 +5,8 @@ import com.backend.domain.menu.repository.MenuRepository;
 import com.backend.domain.order.controller.OrderController;
 import com.backend.domain.order.dto.request.OrderCreateRequest;
 import com.backend.domain.order.dto.request.OrderDetailsCreateRequest;
+import com.backend.domain.order.dto.response.OrderSummaryDetailResponse;
+import com.backend.domain.order.dto.response.OrderSummaryResponse;
 import com.backend.domain.order.entity.OrderDetails;
 import com.backend.domain.order.entity.OrderStatus;
 import com.backend.domain.order.entity.Orders;
@@ -113,7 +115,24 @@ public class OrderService {
         return orderRepository.findById(orderId);
     }
 
-    public List<Orders> getOrdersByUserId(Long userId) {
-        return orderRepository.findByUser_UserId(userId);
+    @Transactional(readOnly = true)
+    public List<OrderSummaryResponse> getOrdersByUserId(Long userId) {
+        List<Orders> orders = orderRepository.findByUser_UserId(userId);
+
+        return orders.stream()
+                .map(order -> new OrderSummaryResponse(
+                        order.getOrderId(),
+                        order.getCreateDate(),
+                        order.getOrderAmount(),
+                        order.getOrderStatus().name(),
+                        order.getOrderDetails().stream()
+                                .map(detail -> new OrderSummaryDetailResponse(
+                                        detail.getMenu().getName(),
+                                        detail.getQuantity(),
+                                        detail.getOrderPrice()
+                                ))
+                                .toList()
+                ))
+                .toList();
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈 
#79 #86

## 📌 과제 설명
일단 와이어프레임 보면서 대략적으로 dto 작성해서 db에 들어가는 것 까지는 확인했습니다.

예외 처리까지 진행 완료 했습니다.
- 사용자가 존재하는지
- 주문 목록이 있는지 확인 하도록 예외처리했습니다!

## 👩‍💻 요구 사항과 구현 내용 
- 컨트롤러 구현
- 로직 구현(주소가 필요할 것 같기는 한데 일단 주석 처리 해놨습니다.)
- dto 작성(OrderSummaryResponse에서 주소 일단 주석 처리 해놨습니다.)
- 예외 처리 진행 중

------------------------------------------------------------------

## ✅ 변경 사항
### OrderCreateRequest 변경
OrderCreateRequest에서 이메일을 받아오도록 했었는데
쿠키를 사용함에 따라
```
public record OrderCreateRequest(
        @Min(0) int amount,
        @NotEmpty List<OrderDetailsCreateRequest> items
) {
}
```
로 변경되었습니다.

### getOrders() 컨트롤러 변경
```
@GetMapping
    @Operation(summary = "사용자 주문 목록 조회")
    public ResponseEntity<ApiResponse<List<OrderSummaryResponse>>> getOrders() {
        //쿠키에서 인증된 유저 가져오기
        Users actor = rq.getUser();
        //주문 조회 로직
        List<OrderSummaryResponse> summaries = orderService.getOrdersByUserId(actor.getUserId());
        return ResponseEntity.ok(ApiResponse.success(summaries));
    }
```

쿠키를 사용함에 따라 @RequestParam 삭제 했습니다.
이제는 get (/api/orders) 로 주문 목록을 조회할 수 있습니다.


임의로 Rq 클래스 안에 getUser에 return null;로 되어있는 부분을 수정해서 했습니다.
```
        return userRepository.getUserByApiKey(apiKey)
                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_MEMBER));

```