### PR TITLE
feature: 메뉴 삭제 기능 추가

### DIFF
--- a/backend/src/main/java/com/backend/domain/menu/controller/MenuController.java
+++ b/backend/src/main/java/com/backend/domain/menu/controller/MenuController.java
@@ -4,18 +4,13 @@ import com.backend.domain.menu.dto.MenuAddRequest;
 import com.backend.domain.menu.dto.MenuResponse;
 import com.backend.domain.menu.dto.MenuUpdateRequest;
 import com.backend.domain.menu.service.MenuService;
-import com.backend.domain.user.user.entity.Users;
-import com.backend.domain.user.user.repository.UserRepository;
 import com.backend.domain.user.user.service.UserService;
-import com.backend.global.exception.BusinessException;
 import com.backend.global.response.ApiResponse;
-import com.backend.global.response.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -26,13 +21,14 @@ import java.util.List;
 public class MenuController {
 
     private final MenuService menuService;
-    private final UserRepository userRepository;
+    private final UserService userService;
 
     // =========== 사용자 ============
 
     @GetMapping("/api/menu")
     @Operation(summary = "메뉴 조회", description = "전체 메뉴(품절 제외)를 조회합니다. (사용자 전용)")
     public ResponseEntity<ApiResponse<List<MenuResponse>>> getAllMenus() {
+        // TODO: 메뉴 조회 로직 구현
         return ResponseEntity.ok(menuService.getAllMenu());
     }
 
@@ -59,6 +55,7 @@ public class MenuController {
     public ResponseEntity<ApiResponse<MenuResponse>> getMenuById(
             @PathVariable Long menuId
     ) {
+        // TODO: 메뉴 상세 조회 로직 구현
         MenuResponse response = menuService.getMenuById(menuId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
@@ -72,5 +69,15 @@ public class MenuController {
         // TODO: 메뉴 수정 로직 구현
         MenuResponse response = menuService.updateMenu(menuId, request);
         return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @DeleteMapping("/api/admin/menu/{menuId}")
+    @Operation(summary = "메뉴 삭제", description = "관리자가 특정 메뉴를 삭제합니다.")
+    public ResponseEntity<ApiResponse<Void>> deleteMenu(
+            @PathVariable Long menuId
+    ) {
+        // TODO: 메뉴 삭제 로직 구현
+        menuService.deleteMenu(menuId);
+        return ResponseEntity.ok(ApiResponse.success(null));
     }
 }

--- a/backend/src/main/java/com/backend/domain/menu/controller/MenuController.java
+++ b/backend/src/main/java/com/backend/domain/menu/controller/MenuController.java
@@ -2,6 +2,7 @@ package com.backend.domain.menu.controller;
 
 import com.backend.domain.menu.dto.MenuAddRequest;
 import com.backend.domain.menu.dto.MenuResponse;
+import com.backend.domain.menu.dto.MenuUpdateRequest;
 import com.backend.domain.menu.service.MenuService;
 import com.backend.domain.user.user.entity.Users;
 import com.backend.domain.user.user.repository.UserRepository;
@@ -42,7 +43,6 @@ public class MenuController {
     public ResponseEntity<ApiResponse<MenuResponse>> createMenu(
             @Valid @RequestBody MenuAddRequest request) {
         // TODO: 메뉴 생성 로직 구현
-
         MenuResponse response = menuService.createMenu(request);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
@@ -50,6 +50,27 @@ public class MenuController {
     @GetMapping("/api/admin/menu")
     @Operation(summary = "메뉴 조회 (관리자)", description = "품절 여부와 상관없이 전체 메뉴를 조회합니다.")
     public ResponseEntity<ApiResponse<List<MenuResponse>>> getAllMenusForAdmin() {
+        // TODO: 메뉴 조회 로직 구현
         return ResponseEntity.ok(menuService.getAllMenuForAdmin());
+    }
+
+    @GetMapping("api/admin/menu/{menuId}")
+    @Operation(summary = "메뉴 상세 조회 (관리자)", description = "특정 메뉴의 상세 정보를 조회합니다.")
+    public ResponseEntity<ApiResponse<MenuResponse>> getMenuById(
+            @PathVariable Long menuId
+    ) {
+        MenuResponse response = menuService.getMenuById(menuId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PutMapping("/api/admin/menu/{menuId}")
+    @Operation(summary = "메뉴 수정", description = "관리자가 특정 메뉴 정보를 수정합니다.")
+    public ResponseEntity<ApiResponse<MenuResponse>> updateMenu(
+            @PathVariable Long menuId,
+            @Valid @RequestBody MenuUpdateRequest request
+    ) {
+        // TODO: 메뉴 수정 로직 구현
+        MenuResponse response = menuService.updateMenu(menuId, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/backend/src/main/java/com/backend/domain/menu/dto/MenuUpdateRequest.java
+++ b/backend/src/main/java/com/backend/domain/menu/dto/MenuUpdateRequest.java
@@ -1,0 +1,29 @@
+package com.backend.domain.menu.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
+
+public record MenuUpdateRequest(
+        @NotBlank(message = "메뉴 이름은 필수입니다.")
+        @Schema(description = "메뉴 이름", example = "콜롬비아 수프리모")
+        String name,
+
+        @Schema(description = "가격", example = "25000")
+        @Positive(message = "가격은 0보다 커야 합니다.")
+        int price,
+
+        @Schema(description = "품절 여부", example = "false")
+        Boolean isSoldOut,
+
+        @Schema(description = "설명", example = "균형잡힌 맛과 부드러운 바디감")
+        String description,
+
+        @Pattern(
+                regexp = "^(https?://).+",
+                message = "이미지 URL은 http:// 또는 https://로 시작해야 합니다."
+        )
+        String imageUrl
+) {
+}

--- a/backend/src/main/java/com/backend/domain/menu/entity/Menu.java
+++ b/backend/src/main/java/com/backend/domain/menu/entity/Menu.java
@@ -2,6 +2,9 @@ package com.backend.domain.menu.entity;
 
 import com.backend.global.jpa.entity.BaseEntity;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -35,6 +38,14 @@ public class Menu extends BaseEntity {
         this.name = name;
         this.price = price;
         this.isSoldOut = isSoldOut != null ? isSoldOut : false;
+        this.description = description;
+        this.imageUrl = imageUrl;
+    }
+
+    public void updateMenu(String name, int price,  Boolean isSoldOut, String description, String imageUrl) {
+        this.name = name;
+        this.price = price;
+        this.isSoldOut = isSoldOut;
         this.description = description;
         this.imageUrl = imageUrl;
     }

--- a/backend/src/main/java/com/backend/domain/menu/repository/MenuRepository.java
+++ b/backend/src/main/java/com/backend/domain/menu/repository/MenuRepository.java
@@ -1,6 +1,7 @@
 package com.backend.domain.menu.repository;
 
 import com.backend.domain.menu.entity.Menu;
+import jakarta.validation.constraints.NotBlank;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -10,4 +11,6 @@ public interface MenuRepository extends JpaRepository<Menu, Long> {
 
     // 품절이 아닌 메뉴만 조회
     List<Menu> findByIsSoldOutFalse();
+
+    boolean existsByNameAndMenuIdNot(String name, Long menuId);
 }

--- a/backend/src/main/java/com/backend/domain/menu/service/MenuService.java
+++ b/backend/src/main/java/com/backend/domain/menu/service/MenuService.java
@@ -87,10 +87,19 @@ public class MenuService {
         return MenuResponse.from(menuRepository.save(menu));
     }
 
+    // 메뉴 상세 조회 (관리자)
     public MenuResponse getMenuById(Long menuId) {
         Menu menu = menuRepository.findById(menuId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_PRODUCT));
 
         return MenuResponse.from(menu);
+    }
+
+    // 메뉴 삭제 (관리자)
+    public void deleteMenu(Long menuId) {
+        Menu menu = menuRepository.findById(menuId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_PRODUCT));
+
+        menuRepository.delete(menu);
     }
 }

--- a/backend/src/main/java/com/backend/domain/menu/service/MenuService.java
+++ b/backend/src/main/java/com/backend/domain/menu/service/MenuService.java
@@ -2,11 +2,13 @@ package com.backend.domain.menu.service;
 
 import com.backend.domain.menu.dto.MenuAddRequest;
 import com.backend.domain.menu.dto.MenuResponse;
+import com.backend.domain.menu.dto.MenuUpdateRequest;
 import com.backend.domain.menu.entity.Menu;
 import com.backend.domain.menu.repository.MenuRepository;
 import com.backend.global.exception.BusinessException;
 import com.backend.global.response.ApiResponse;
 import com.backend.global.response.ErrorCode;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -62,5 +64,33 @@ public class MenuService {
                 .toList();
 
         return ApiResponse.success(menus);
+    }
+
+    // 메뉴 수정 (관리자)
+    public MenuResponse updateMenu(Long menuId, @Valid MenuUpdateRequest request) {
+        Menu menu = menuRepository.findById(menuId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_PRODUCT));
+
+        // 메뉴 이름 중복 체크 (자기 자신 제외)
+        if (menuRepository.existsByNameAndMenuIdNot(request.name(), menuId)) {
+            throw new BusinessException(ErrorCode.DUPLICATE_MENU_NAME);
+        }
+
+        menu.updateMenu(
+                request.name(),
+                request.price(),
+                request.isSoldOut(),
+                request.description(),
+                request.imageUrl()
+        );
+
+        return MenuResponse.from(menuRepository.save(menu));
+    }
+
+    public MenuResponse getMenuById(Long menuId) {
+        Menu menu = menuRepository.findById(menuId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_PRODUCT));
+
+        return MenuResponse.from(menu);
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈 <!-- 이슈 번호를 적어주세요 -->
#85 

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
관리자가 기존에 등록된 메뉴를 삭제할 수 있는 메뉴 삭제 API (DELETE /api/admin/menu/{menuId})를 구현했습니다.
관리자는 더 이상 판매하지 않는 메뉴를 DB에서 제거할 수 있습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- 메뉴 ID로 엔티티 조회 (findById)
- 존재하지 않을 경우 BusinessException(ErrorCode.NOT_FOUND_PRODUCT) 발생
- 메뉴 존재 시 menuRepository.delete() 호출
- MenuController.deleteMenu() 구현
- DELETE /api/admin/menu/{menuId} 엔드포인트 추가
- 삭제 성공 시 ApiResponse.success(null) 반환

[3번 메뉴 삭제]
<img width="1635" height="908" alt="image" src="https://github.com/user-attachments/assets/ca7f6c12-ffc9-402b-a9f2-c8fcb038e236" />

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
