### PR TITLE
feat: PaymentMethod 관련 enum 추가, PaymentDTO 개선

### DIFF
--- a/backend/src/main/java/com/backend/domain/payment/dto/request/PaymentCreateRequest.java
+++ b/backend/src/main/java/com/backend/domain/payment/dto/request/PaymentCreateRequest.java
@@ -2,16 +2,29 @@ package com.backend.domain.payment.dto.request;
 
 import com.backend.domain.order.entity.Orders;
 import com.backend.domain.payment.entity.Payment;
+import com.backend.domain.payment.entity.PaymentMethod;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 
 /*
  * 결제 요청 DTO
  */
 public record PaymentCreateRequest(
+        @NotNull(message = "주문 ID는 필수입니다.")
+        @Positive(message = "주문 ID는 양수여야 합니다.")
         Long orderId,
+
+        @Positive(message = "결제 금액은 양수여야 합니다.")
         int paymentAmount,
-        String paymentMethod
+
+        @NotNull(message = "결제 방법은 필수입니다.")
+        PaymentMethod paymentMethod
 ) {
     public Payment createPayment(Orders orders) {
-        return new Payment(paymentAmount, paymentMethod, orders);
+        return Payment.builder()
+                .paymentAmount(paymentAmount)
+                .paymentMethod(paymentMethod)
+                .orders(orders)
+                .build();
     }
 }

--- a/backend/src/main/java/com/backend/domain/payment/dto/response/PaymentCreateResponse.java
+++ b/backend/src/main/java/com/backend/domain/payment/dto/response/PaymentCreateResponse.java
@@ -1,6 +1,7 @@
 package com.backend.domain.payment.dto.response;
 
 import com.backend.domain.payment.entity.Payment;
+import com.backend.domain.payment.entity.PaymentMethod;
 import com.backend.domain.payment.entity.PaymentStatus;
 import lombok.Builder;
 
@@ -13,7 +14,7 @@ import java.time.LocalDateTime;
 public record PaymentCreateResponse(
         Long paymentId,
         int paymentAmount,
-        String paymentMethod,
+        PaymentMethod paymentMethod,
         PaymentStatus paymentStatus,
         LocalDateTime createDate,
         LocalDateTime modifyDate

--- a/backend/src/main/java/com/backend/domain/payment/dto/response/PaymentInquiryResponse.java
+++ b/backend/src/main/java/com/backend/domain/payment/dto/response/PaymentInquiryResponse.java
@@ -1,6 +1,7 @@
 package com.backend.domain.payment.dto.response;
 
 import com.backend.domain.payment.entity.Payment;
+import com.backend.domain.payment.entity.PaymentMethod;
 import com.backend.domain.payment.entity.PaymentStatus;
 
 import java.time.LocalDateTime;
@@ -8,7 +9,7 @@ import java.time.LocalDateTime;
 public record PaymentInquiryResponse(
         Long paymentId,
         int paymentAmount,
-        String paymentMethod,
+        PaymentMethod paymentMethod,
         PaymentStatus paymentStatus,
         LocalDateTime createDate,
         LocalDateTime modifyDate

--- a/backend/src/main/java/com/backend/domain/payment/entity/Payment.java
+++ b/backend/src/main/java/com/backend/domain/payment/entity/Payment.java
@@ -22,8 +22,9 @@ public class Payment extends BaseEntity {
     private int paymentAmount;
 
     // 결제 유형, NOT NULL [ex: 카드 결제]
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 30)
-    private String paymentMethod;
+    private PaymentMethod paymentMethod;
 
     // 결제 상태, NOT NULL [결제 전 / 결제 완료]
     @Enumerated(EnumType.STRING)
@@ -35,7 +36,7 @@ public class Payment extends BaseEntity {
     private Orders orders;
 
     @Builder
-    public Payment(int paymentAmount, String paymentMethod, Orders orders) {
+    public Payment(int paymentAmount, PaymentMethod  paymentMethod, Orders orders) {
         this.paymentAmount = paymentAmount;
         this.paymentMethod = paymentMethod;
         this.paymentStatus = PaymentStatus.PENDING;

--- a/backend/src/main/java/com/backend/domain/payment/entity/PaymentMethod.java
+++ b/backend/src/main/java/com/backend/domain/payment/entity/PaymentMethod.java
@@ -1,0 +1,15 @@
+package com.backend.domain.payment.entity;
+
+public enum PaymentMethod {
+    CARD("카드 결제");
+
+    private final String description;
+
+    PaymentMethod(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/backend/src/main/java/com/backend/domain/payment/service/PaymentService.java
+++ b/backend/src/main/java/com/backend/domain/payment/service/PaymentService.java
@@ -7,6 +7,7 @@ import com.backend.domain.payment.dto.request.PaymentCreateRequest;
 import com.backend.domain.payment.dto.response.PaymentCreateResponse;
 import com.backend.domain.payment.dto.response.PaymentInquiryResponse;
 import com.backend.domain.payment.entity.Payment;
+import com.backend.domain.payment.entity.PaymentMethod;
 import com.backend.domain.payment.entity.PaymentStatus;
 import com.backend.domain.payment.repository.PaymentRepository;
 import com.backend.global.exception.BusinessException;
@@ -37,6 +38,14 @@ public class PaymentService {
             throw new BusinessException(ErrorCode.PAYMENT_AMOUNT_MISMATCH);
         }
 
+        if(request.paymentMethod() == null) {
+            throw new BusinessException(ErrorCode.INVALID_PAYMENT_METHOD);
+        }
+
+        if(request.paymentMethod() == PaymentMethod.CARD) {
+            throw new BusinessException(ErrorCode.INVALID_PAYMENT_METHOD);
+        }
+
         boolean completePayment = paymentRepository.existsByOrdersAndPaymentStatus(orders, PaymentStatus.COMPLETED);
         if(completePayment) {
             throw new BusinessException(ErrorCode.PAYMENT_ALREADY_COMPLETED);
@@ -44,9 +53,6 @@ public class PaymentService {
 
         Payment payment = request.createPayment(orders);
         Payment savePayment = paymentRepository.save(payment);
-
-        orders.setPayment(savePayment);
-        orderRepository.save(orders);
 
         orders.setPayment(savePayment);
         orders.setOrderStatus(OrderStatus.PAID);


### PR DESCRIPTION
## #️⃣ 연관된 이슈 <!-- 이슈 번호를 적어주세요 -->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
예지 님이 말씀하신 방식으로 Service에서 Payment builder 이용하는 부분을 DTO에 메소드 만들어 분리 작성했고, 
GlobalExceptionHandler 이용한 에러 처리 방식도 진행 중에 있습니다!

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
PaymentCreateRequest.java
```   public Payment createPayment(Orders orders) {
        return Payment.builder()
                .paymentAmount(paymentAmount)
                .paymentMethod(paymentMethod)
                .orders(orders)
                .build();
    }
```
PaymentService.java
```
        Payment payment = request.createPayment(orders);
```

--
에러 처리 결과 예시1. 이미 결제된 주문을 다시 결제하고자 할 때
<img width="1399" height="271" alt="image" src="https://github.com/user-attachments/assets/1683684b-4e05-4147-9d0e-7bd4c1a3435f" />

외에 주문 금액과 결제 금액이 동일하지 않을 때, 결제 금액이 0보다 작거나 음수일 때, 결제 방식이 허락되지 않은 방식일 때 예외 처리 해 두었습니다!
추후 최종 수정 때 추가해 작성하도록 하겠습니다.