### PR TITLE
refactor(menu): 엔티티 개선 및 관리자 권한 검증 로직 개선

### DIFF
--- a/backend/src/main/java/com/backend/domain/menu/controller/MenuController.java
+++ b/backend/src/main/java/com/backend/domain/menu/controller/MenuController.java
@@ -4,8 +4,12 @@ import com.backend.domain.menu.dto.MenuAddRequest;
 import com.backend.domain.menu.dto.MenuResponse;
 import com.backend.domain.menu.dto.MenuUpdateRequest;
 import com.backend.domain.menu.service.MenuService;
+import com.backend.domain.user.user.dto.UserDto;
 import com.backend.domain.user.user.service.UserService;
+import com.backend.global.exception.BusinessException;
 import com.backend.global.response.ApiResponse;
+import com.backend.global.response.ErrorCode;
+import com.backend.global.rq.Rq;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -21,7 +25,15 @@ import java.util.List;
 public class MenuController {
 
     private final MenuService menuService;
-    private final UserService userService;
+    private final Rq rq;
+
+    private void validateAdmin(UserDto actor)
+    {
+        if(actor.level() != 1)          //아직 관리자 레벨을 정하지 않아 임시로 1로 지정
+        {
+            throw new BusinessException(ErrorCode.FORBIDDEN_ADMIN);
+        }
+    }
 
     // =========== 사용자 ============
 
@@ -37,7 +49,10 @@ public class MenuController {
     @PostMapping("/api/admin/menu")
     @Operation(summary = "메뉴 생성", description = "새로운 메뉴를 생성합니다. (관리자 전용)")
     public ResponseEntity<ApiResponse<MenuResponse>> createMenu(
-            @Valid @RequestBody MenuAddRequest request) {
+            @Valid @RequestBody MenuAddRequest request) throws Exception {
+        UserDto actor = rq.getUser();
+        validateAdmin(actor);
+
         // TODO: 메뉴 생성 로직 구현
         MenuResponse response = menuService.createMenu(request);
         return ResponseEntity.ok(ApiResponse.success(response));
@@ -45,7 +60,9 @@ public class MenuController {
 
     @GetMapping("/api/admin/menu")
     @Operation(summary = "메뉴 조회 (관리자)", description = "품절 여부와 상관없이 전체 메뉴를 조회합니다.")
-    public ResponseEntity<ApiResponse<List<MenuResponse>>> getAllMenusForAdmin() {
+    public ResponseEntity<ApiResponse<List<MenuResponse>>> getAllMenusForAdmin() throws Exception {
+        UserDto actor = rq.getUser();
+        validateAdmin(actor);
         // TODO: 메뉴 조회 로직 구현
         return ResponseEntity.ok(menuService.getAllMenuForAdmin());
     }
@@ -54,7 +71,9 @@ public class MenuController {
     @Operation(summary = "메뉴 상세 조회 (관리자)", description = "특정 메뉴의 상세 정보를 조회합니다.")
     public ResponseEntity<ApiResponse<MenuResponse>> getMenuById(
             @PathVariable Long menuId
-    ) {
+    ) throws Exception {
+        UserDto actor = rq.getUser();
+        validateAdmin(actor);
         // TODO: 메뉴 상세 조회 로직 구현
         MenuResponse response = menuService.getMenuById(menuId);
         return ResponseEntity.ok(ApiResponse.success(response));
@@ -65,7 +84,9 @@ public class MenuController {
     public ResponseEntity<ApiResponse<MenuResponse>> updateMenu(
             @PathVariable Long menuId,
             @Valid @RequestBody MenuUpdateRequest request
-    ) {
+    ) throws Exception {
+        UserDto actor = rq.getUser();
+        validateAdmin(actor);
         // TODO: 메뉴 수정 로직 구현
         MenuResponse response = menuService.updateMenu(menuId, request);
         return ResponseEntity.ok(ApiResponse.success(response));
@@ -75,7 +96,9 @@ public class MenuController {
     @Operation(summary = "메뉴 삭제", description = "관리자가 특정 메뉴를 삭제합니다.")
     public ResponseEntity<ApiResponse<Void>> deleteMenu(
             @PathVariable Long menuId
-    ) {
+    ) throws Exception {
+        UserDto actor = rq.getUser();
+        validateAdmin(actor);
         // TODO: 메뉴 삭제 로직 구현
         menuService.deleteMenu(menuId);
         return ResponseEntity.ok(ApiResponse.success(null));

--- a/backend/src/main/java/com/backend/domain/menu/dto/MenuAddRequest.java
+++ b/backend/src/main/java/com/backend/domain/menu/dto/MenuAddRequest.java
@@ -1,5 +1,6 @@
 package com.backend.domain.menu.dto;
 
+import com.backend.domain.menu.entity.Menu;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
@@ -26,4 +27,14 @@ public record MenuAddRequest(
         )
         String imageUrl
 ) {
+    // DTO를 메뉴 엔티티로 변환하는 메서드
+    public Menu toEntity() {
+        return Menu.builder()
+                .name(this.name)
+                .price(this.price)
+                .isSoldOut(this.isSoldOut)
+                .description(this.description)
+                .imageUrl(this.imageUrl)
+                .build();
+    }
 }

--- a/backend/src/main/java/com/backend/domain/menu/dto/MenuUpdateRequest.java
+++ b/backend/src/main/java/com/backend/domain/menu/dto/MenuUpdateRequest.java
@@ -1,5 +1,6 @@
 package com.backend.domain.menu.dto;
 
+import com.backend.domain.menu.entity.Menu;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
@@ -26,4 +27,14 @@ public record MenuUpdateRequest(
         )
         String imageUrl
 ) {
+    // 메뉴 엔티티에 업데이트 적용 메서드
+    public void applyTo(Menu menu) {
+        menu.updateMenu(
+                this.name,
+                this.price,
+                this.isSoldOut,
+                this.description,
+                this.imageUrl
+        );
+    }
 }

--- a/backend/src/main/java/com/backend/domain/menu/entity/Menu.java
+++ b/backend/src/main/java/com/backend/domain/menu/entity/Menu.java
@@ -5,6 +5,7 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Positive;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -34,6 +35,8 @@ public class Menu extends BaseEntity {
     @Column(length = 255)
     private String imageUrl;    // 메뉴 이미지 URL
 
+    // 생성자
+    @Builder
     public Menu(String name, int price, Boolean isSoldOut, String description, String imageUrl) {
         this.name = name;
         this.price = price;
@@ -42,6 +45,7 @@ public class Menu extends BaseEntity {
         this.imageUrl = imageUrl;
     }
 
+    // 메뉴 정보 업데이트 메서드
     public void updateMenu(String name, int price,  Boolean isSoldOut, String description, String imageUrl) {
         this.name = name;
         this.price = price;

--- a/backend/src/main/java/com/backend/domain/menu/service/MenuService.java
+++ b/backend/src/main/java/com/backend/domain/menu/service/MenuService.java
@@ -36,24 +36,12 @@ public class MenuService {
     // 메뉴 생성 (관리자)
     public MenuResponse createMenu(MenuAddRequest request) {
 
-        // 관리자 권한 체크
-//        if (user.getLevel() != 1) { // 예: 1 = 관리자
-//            throw new BusinessException(ErrorCode.FORBIDDEN_ADMIN);
-//        }
-
         // 메뉴 이름 중복 체크
         if (menuRepository.existsByName(request.name())) {
             throw new BusinessException(ErrorCode.DUPLICATE_MENU_NAME);
         }
 
-        Menu menu = new Menu(
-                request.name(),
-                request.price(),
-                request.isSoldOut(),
-                request.description(),
-                request.imageUrl()
-        );
-
+        Menu menu = request.toEntity();
         return MenuResponse.from(menuRepository.save(menu));
     }
 
@@ -76,14 +64,7 @@ public class MenuService {
             throw new BusinessException(ErrorCode.DUPLICATE_MENU_NAME);
         }
 
-        menu.updateMenu(
-                request.name(),
-                request.price(),
-                request.isSoldOut(),
-                request.description(),
-                request.imageUrl()
-        );
-
+        request.applyTo(menu); // DTO → 엔티티 갱신
         return MenuResponse.from(menuRepository.save(menu));
     }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈 <!-- 이슈 번호를 적어주세요 -->
#100

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
예지님이 말씀하신 서비스 부분에서 new 보다는 DTO부분에서 rebuild로 처리 하는게 나을 것 같아 개선했습니다.
관리자 권한 검증 로직을 컨트롤러에 적용했습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- MenuAddRequest DTO에 toEntity() 메서드 추가 (Builder 활용)
- MenuService에서 엔티티 변환 로직 제거
- 관리자 권한 검증 메서드(validateAdmin) 추가
- 메뉴 생성/수정/삭제 API 컨트롤러에 관리자 권한 검증 적용

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 현재 Rq.getUser()에서 throws Exception이 선언되어 있어 컨트롤러 메서드에도 throws Exception을 붙였습니다. 
- 관리자 권한 레벨을 하드코딩(1)으로 비교하고 있는데, 추후 enum 전역변수로 선언해두는게 나을 것 같습니다.
