### PR TITLE
feature: 결제 단건 취소 API

### DIFF
--- a/backend/src/main/java/com/backend/domain/payment/controller/PaymentController.java
+++ b/backend/src/main/java/com/backend/domain/payment/controller/PaymentController.java
@@ -1,10 +1,12 @@
 package com.backend.domain.payment.controller;
 
 import com.backend.domain.payment.dto.request.PaymentCreateRequest;
+import com.backend.domain.payment.dto.response.PaymentCancelResponse;
 import com.backend.domain.payment.dto.response.PaymentCreateResponse;
 import com.backend.domain.payment.dto.response.PaymentInquiryResponse;
 import com.backend.domain.payment.service.PaymentService;
 import com.backend.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,6 +35,20 @@ public class PaymentController {
             @Valid @PathVariable Long paymentId
     ) {
         PaymentInquiryResponse response = paymentService.getPayment(paymentId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    // 결제 단건 삭제 API
+    @Operation(
+            summary = "결제 취소",
+            description = "완료(COMPLETED)된 결제를 취소(CANCELED) 상태로 변경합니다. " +
+                    "이미 취소된 결제나 취소 불가능한 상태의 결제는 에러를 반환합니다."
+    )
+    @PutMapping("/{paymentId}/cancel")
+    public ResponseEntity<ApiResponse<PaymentCancelResponse>> cancelPayment(
+            @Valid @PathVariable Long paymentId
+    ) {
+        PaymentCancelResponse response = paymentService.cancelPayment(paymentId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/backend/src/main/java/com/backend/domain/payment/dto/response/PaymentCancelResponse.java
+++ b/backend/src/main/java/com/backend/domain/payment/dto/response/PaymentCancelResponse.java
@@ -1,0 +1,27 @@
+package com.backend.domain.payment.dto.response;
+
+import com.backend.domain.payment.entity.Payment;
+import com.backend.domain.payment.entity.PaymentMethod;
+import com.backend.domain.payment.entity.PaymentStatus;
+
+import java.time.LocalDateTime;
+
+public record PaymentCancelResponse (
+        Long paymentId,
+        int paymentAmount,
+        PaymentMethod paymentMethod,
+        PaymentStatus paymentStatus,
+        LocalDateTime createDate,
+        LocalDateTime modifyDate
+) {
+    public PaymentCancelResponse(Payment payment) {
+        this(
+                payment.getPaymentId(),
+                payment.getPaymentAmount(),
+                payment.getPaymentMethod(),
+                payment.getPaymentStatus(),
+                payment.getCreateDate(),
+                payment.getModifyDate()
+        );
+    }
+}

--- a/backend/src/main/java/com/backend/domain/payment/entity/Payment.java
+++ b/backend/src/main/java/com/backend/domain/payment/entity/Payment.java
@@ -49,4 +49,11 @@ public class Payment extends BaseEntity {
         }
         this.paymentStatus = PaymentStatus.COMPLETED;
     }
+
+    public void cancel() {
+        if(this.paymentStatus == PaymentStatus.CANCELLED) {
+            throw new BusinessException(ErrorCode.PAYMENT_ALREADY_CANCELLED);
+        }
+        this.paymentStatus = PaymentStatus.CANCELLED;
+    }
 }

--- a/backend/src/main/java/com/backend/domain/payment/service/PaymentService.java
+++ b/backend/src/main/java/com/backend/domain/payment/service/PaymentService.java
@@ -4,6 +4,7 @@ import com.backend.domain.order.entity.OrderStatus;
 import com.backend.domain.order.entity.Orders;
 import com.backend.domain.order.repository.OrderRepository;
 import com.backend.domain.payment.dto.request.PaymentCreateRequest;
+import com.backend.domain.payment.dto.response.PaymentCancelResponse;
 import com.backend.domain.payment.dto.response.PaymentCreateResponse;
 import com.backend.domain.payment.dto.response.PaymentInquiryResponse;
 import com.backend.domain.payment.entity.Payment;
@@ -12,6 +13,7 @@ import com.backend.domain.payment.entity.PaymentStatus;
 import com.backend.domain.payment.repository.PaymentRepository;
 import com.backend.global.exception.BusinessException;
 import com.backend.global.response.ErrorCode;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -73,5 +75,28 @@ public class PaymentService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_PAYMENT));
 
         return new PaymentInquiryResponse(payment);
+    }
+
+    // 결제 단건 취소
+    @Transactional
+    public PaymentCancelResponse cancelPayment(@Valid Long paymentId) {
+        if(paymentId == null || paymentId <= 0) {
+            throw new BusinessException(ErrorCode.NOT_FOUND_PAYMENT);
+        }
+
+        Payment payment = paymentRepository.findById(paymentId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_PAYMENT));
+
+        if(payment.getPaymentStatus() == PaymentStatus.CANCELLED) {
+            throw new BusinessException(ErrorCode.PAYMENT_ALREADY_CANCELLED);
+        }
+
+        if(payment.getPaymentStatus() != PaymentStatus.COMPLETED) {
+            throw new BusinessException(ErrorCode.PAYMENT_NOT_CANCELLABLE);
+        }
+
+        payment.cancel();
+
+        return new PaymentCancelResponse(payment);
     }
 }

--- a/backend/src/main/java/com/backend/global/response/ErrorCode.java
+++ b/backend/src/main/java/com/backend/global/response/ErrorCode.java
@@ -39,7 +39,7 @@ public enum ErrorCode {
     PAYMENT_ALREADY_COMPLETED("P002", HttpStatus.CONFLICT, "이미 완료된 결제입니다."),
     PAYMENT_FAILED("P003", HttpStatus.PAYMENT_REQUIRED, "결제 처리에 실패했습니다."),
     NOT_FOUND_PAYMENT("P004", HttpStatus.NOT_FOUND, "존재하지 않는 결제입니다."),
-    PAYMENT_CANCELLED("P005", HttpStatus.CONFLICT, "취소된 결제입니다."),
+    PAYMENT_ALREADY_CANCELLED("P005", HttpStatus.CONFLICT, "이미 취소된 결제입니다."),
     INVALID_PAYMENT_METHOD("P006", HttpStatus.BAD_REQUEST, "유효하지 않은 결제 방법입니다."),
     PAYMENT_AMOUNT_MISMATCH("P007", HttpStatus.BAD_REQUEST, "주문 금액과 결제 금액이 일치하지 않습니다."),
     PAYMENT_NOT_CANCELLABLE("P008", HttpStatus.CONFLICT, "취소할 수 없는 결제 상태입니다."),


### PR DESCRIPTION
## #️⃣ 연관된 이슈 <!-- 이슈 번호를 적어주세요 -->
Closed #110 

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
결제 단건 취소 API 구현했습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
5c15309
1. PaymentController -> PUT 요청의 /api/payments/{paymentId}/cancel 생성
```
@PutMapping("/{paymentId}/cancel")
    public ResponseEntity<ApiResponse<PaymentCancelResponse>> cancelPayment(
            @Valid @PathVariable Long paymentId
    )
... 중략
```
2. PaymentCancelResponse -> 결제 단건 취소 응답 DTO
3. Payment -> 결제 단건 취소 관련 비즈니스 로직 작성
```
    public void cancel() {
        if(this.paymentStatus == PaymentStatus.CANCELLED) {
            throw new BusinessException(ErrorCode.PAYMENT_ALREADY_CANCELLED);
        }
        this.paymentStatus = PaymentStatus.CANCELLED;
    }
```
4. PaymentService -> 결제 단건 취소 관련 서비스 로직 작성
```
@Transactional
    public PaymentCancelResponse cancelPayment(@Valid Long paymentId) {
... 중략
```

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
<img width="1324" height="809" alt="image" src="https://github.com/user-attachments/assets/ca327875-8587-4f00-9e57-3d4980bea772" />
