### PR TITLE
feat: 결제 단건 삭제 API, Payment 도메인 전반 사용자 검증 도입

### DIFF
--- a/backend/src/main/java/com/backend/domain/order/repository/OrderRepository.java
+++ b/backend/src/main/java/com/backend/domain/order/repository/OrderRepository.java
@@ -4,7 +4,12 @@ import com.backend.domain.order.entity.Orders;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface OrderRepository extends JpaRepository<Orders, Long> {
     List<Orders> findByUser_UserId(Long userId);
+
+    // 특정 주문이 요청한 사용자의 소유인지 검증하며 주문 조회
+    // (결제 권한 검증용: Payment → Orders → User 경로로 소유자 확인)
+    Optional<Orders> findByOrderIdAndUser_UserId(Long orderId, Long userId);
 }

--- a/backend/src/main/java/com/backend/domain/payment/controller/PaymentController.java
+++ b/backend/src/main/java/com/backend/domain/payment/controller/PaymentController.java
@@ -49,7 +49,7 @@ public class PaymentController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    // 결제 단건 삭제 API
+    // 결제 단건 취소 API
     @Operation(
             summary = "결제 취소",
             description = "완료(COMPLETED)된 결제를 취소(CANCELED) 상태로 변경합니다. " +

--- a/backend/src/main/java/com/backend/domain/payment/controller/PaymentController.java
+++ b/backend/src/main/java/com/backend/domain/payment/controller/PaymentController.java
@@ -5,22 +5,23 @@ import com.backend.domain.payment.dto.response.PaymentCancelResponse;
 import com.backend.domain.payment.dto.response.PaymentCreateResponse;
 import com.backend.domain.payment.dto.response.PaymentInquiryResponse;
 import com.backend.domain.payment.service.PaymentService;
+import com.backend.domain.user.user.dto.UserDto;
 import com.backend.global.response.ApiResponse;
+import com.backend.global.rq.Rq;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/payments")
 @RequiredArgsConstructor
-@Slf4j
 @Tag(name = "Payment", description = "결제 API")
 public class PaymentController {
     private final PaymentService paymentService;
+    private final Rq rq;
 
     // 결제 생성 API
     @Operation(
@@ -31,8 +32,9 @@ public class PaymentController {
     @PostMapping("/create")
     public ResponseEntity<ApiResponse<PaymentCreateResponse>> createPayment(
             @Valid @RequestBody PaymentCreateRequest request
-            ) {
-        PaymentCreateResponse response = paymentService.createPayment(request);
+            ) throws Exception {
+        UserDto currentUser = rq.getUser();
+        PaymentCreateResponse response = paymentService.createPayment(request, currentUser);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
@@ -44,8 +46,9 @@ public class PaymentController {
     @GetMapping("/{paymentId}")
     public ResponseEntity<ApiResponse<PaymentInquiryResponse>> getPayment(
             @Valid @PathVariable Long paymentId
-    ) {
-        PaymentInquiryResponse response = paymentService.getPayment(paymentId);
+    ) throws Exception {
+        UserDto currentUser = rq.getUser();
+        PaymentInquiryResponse response = paymentService.getPayment(paymentId, currentUser);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
@@ -58,8 +61,9 @@ public class PaymentController {
     @PutMapping("/{paymentId}/cancel")
     public ResponseEntity<ApiResponse<PaymentCancelResponse>> cancelPayment(
             @Valid @PathVariable Long paymentId
-    ) {
-        PaymentCancelResponse response = paymentService.cancelPayment(paymentId);
+    ) throws Exception {
+        UserDto currentUser = rq.getUser();
+        PaymentCancelResponse response = paymentService.cancelPayment(paymentId, currentUser);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
@@ -72,8 +76,9 @@ public class PaymentController {
     @DeleteMapping("/{paymentId}/delete")
     public ResponseEntity<ApiResponse<Void>> deletePayment(
             @Valid @PathVariable Long paymentId
-    ){
-        paymentService.deletePayment(paymentId);
+    ) throws Exception {
+        UserDto currentUser = rq.getUser();
+        paymentService.deletePayment(paymentId, currentUser);
         return ResponseEntity.ok(ApiResponse.success());
     }
 }

--- a/backend/src/main/java/com/backend/domain/payment/controller/PaymentController.java
+++ b/backend/src/main/java/com/backend/domain/payment/controller/PaymentController.java
@@ -62,4 +62,18 @@ public class PaymentController {
         PaymentCancelResponse response = paymentService.cancelPayment(paymentId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
+
+    // 취소된 결제 내역 삭제
+    @Operation(
+            summary = "결제 삭제",
+            description = "취소(CANCELED) 상태의 결제 내역만 삭제합니다. " +
+                    "취소되지 않았거나, 존재하지 않는 paymentId에 대한 삭제를 요청할 시 에러를 반환합니다."
+    )
+    @DeleteMapping("/{paymentId}/delete")
+    public ResponseEntity<ApiResponse<Void>> deletePayment(
+            @Valid @PathVariable Long paymentId
+    ){
+        paymentService.deletePayment(paymentId);
+        return ResponseEntity.ok(ApiResponse.success());
+    }
 }

--- a/backend/src/main/java/com/backend/domain/payment/entity/Payment.java
+++ b/backend/src/main/java/com/backend/domain/payment/entity/Payment.java
@@ -51,9 +51,9 @@ public class Payment extends BaseEntity {
     }
 
     public void cancel() {
-        if(this.paymentStatus == PaymentStatus.CANCELLED) {
+        if(this.paymentStatus == PaymentStatus.CANCELED) {
             throw new BusinessException(ErrorCode.PAYMENT_ALREADY_CANCELLED);
         }
-        this.paymentStatus = PaymentStatus.CANCELLED;
+        this.paymentStatus = PaymentStatus.CANCELED;
     }
 }

--- a/backend/src/main/java/com/backend/domain/payment/entity/PaymentStatus.java
+++ b/backend/src/main/java/com/backend/domain/payment/entity/PaymentStatus.java
@@ -7,7 +7,7 @@ public enum PaymentStatus {
     PENDING("결제 전"),
     COMPLETED("결제 완료"),
     FAILED("결제 실패"),
-    CANCELLED("결제 취소");
+    CANCELED("결제 취소");
 
     private final String description;
 

--- a/backend/src/main/java/com/backend/domain/payment/repository/PaymentRepository.java
+++ b/backend/src/main/java/com/backend/domain/payment/repository/PaymentRepository.java
@@ -5,6 +5,10 @@ import com.backend.domain.payment.entity.Payment;
 import com.backend.domain.payment.entity.PaymentStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
     boolean existsByOrdersAndPaymentStatus(Orders orders, PaymentStatus paymentStatus);
+
+    Optional<Payment> findByPaymentIdAndOrders_User_UserId(Long paymentId, Long userId);
 }

--- a/backend/src/main/java/com/backend/domain/payment/service/PaymentService.java
+++ b/backend/src/main/java/com/backend/domain/payment/service/PaymentService.java
@@ -79,7 +79,7 @@ public class PaymentService {
         Payment payment = paymentRepository.findById(paymentId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_PAYMENT));
 
-        if(payment.getPaymentStatus() == PaymentStatus.CANCELLED) {
+        if(payment.getPaymentStatus() == PaymentStatus.CANCELED) {
             throw new BusinessException(ErrorCode.PAYMENT_ALREADY_CANCELLED);
         }
 
@@ -90,5 +90,26 @@ public class PaymentService {
         payment.cancel();
 
         return new PaymentCancelResponse(payment);
+    }
+
+    // 취소된 결제 내역 삭제
+    @Transactional
+    public void deletePayment(@Valid Long paymentId) {
+        if(paymentId == null || paymentId <= 0) {
+            throw new BusinessException(ErrorCode.NOT_FOUND_PAYMENT);
+        }
+
+        Payment payment = paymentRepository.findById(paymentId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_PAYMENT));
+
+        if(payment.getPaymentStatus() != PaymentStatus.CANCELED) {
+            throw new BusinessException(ErrorCode.PAYMENT_DELETE_FAILED);
+        }
+
+        if(payment.getOrders() != null) {
+            payment.getOrders().setPayment(null);
+        }
+
+        paymentRepository.delete(payment);
     }
 }

--- a/backend/src/main/java/com/backend/global/response/ErrorCode.java
+++ b/backend/src/main/java/com/backend/global/response/ErrorCode.java
@@ -46,6 +46,7 @@ public enum ErrorCode {
     INVALID_PAYMENT_METHOD("P006", HttpStatus.BAD_REQUEST, "유효하지 않은 결제 방법입니다."),
     PAYMENT_AMOUNT_MISMATCH("P007", HttpStatus.BAD_REQUEST, "주문 금액과 결제 금액이 일치하지 않습니다."),
     PAYMENT_NOT_CANCELLABLE("P008", HttpStatus.CONFLICT, "취소할 수 없는 결제 상태입니다."),
+    PAYMENT_DELETE_FAILED("P009", HttpStatus.BAD_REQUEST, "취소된 결제 내역만 삭제 가능합니다."),
 
     // 메뉴
     DUPLICATE_MENU_NAME("M001", HttpStatus.CONFLICT, "이미 존재하는 메뉴 이름입니다."),


### PR DESCRIPTION
## #️⃣ 연관된 이슈 <!-- 이슈 번호를 적어주세요 -->
Closed #118 
Closed #124 

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
결제 단건 삭제 API 작성
Payment 전반에 Rq 도입, 사용자 검증

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
e717368: 결제 단건 취소로 작성되어야 하는데 결제 단건 삭제로 작성되어 있던 주석을 수정했습니다
9b5510f: 결제 단건 삭제 API
1. 사용자가 결제 취소된 건에 대해 데이터 삭제 요청을 할 경우 삭제 진행
2. 단, 결제가 취소된 건에 대해서만 삭제 요청 가능. 외에는 오류 처리
3. PaymentController, PaymentService, Payment, ErrorCode 수정했습니다!
4. **PaymentStatus enum 파일에서 CANCELLD -> CANCELD 오타 수정했습니다. -> Payment 테이블 삭제 후 다시 생성 부탁드립니다...**


**7529c1a: Payment 전반에 Rq 도입, 사용자 검증**
따로 브랜치를 파서 작업하려다가 delete도 추가적으로 작업되어야 하기에 한 브랜치에 작업했습니다...
1. OrderRepository 코드 payment -> order -> user 검증 코드 추가
```java
// 특정 주문이 요청한 사용자의 소유인지 검증하며 주문 조회
// (결제 권한 검증용: Payment → Orders → User 경로로 소유자 확인)
Optional<Orders> findByOrderIdAndUser_UserId(Long orderId, Long userId);
```
2. PaymentController, PaymentService 전반에 rq 도입 및 검증 코드 추가

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
<img width="1321" height="710" alt="image" src="https://github.com/user-attachments/assets/5ce4b265-cf59-4289-8dd9-9b43cde924e8" />
<img width="1302" height="469" alt="image" src="https://github.com/user-attachments/assets/cce29e05-8d63-4e09-bb74-1a34a3f314ed" />