### PR TITLE
fix: 메뉴 컨트롤러 관리자 권한 레벨 수정

### DIFF
--- a/backend/src/main/java/com/backend/domain/menu/controller/MenuController.java
+++ b/backend/src/main/java/com/backend/domain/menu/controller/MenuController.java
@@ -29,7 +29,7 @@ public class MenuController {
 
     private void validateAdmin(UserDto actor)
     {
-        if(actor.level() != 1)          //아직 관리자 레벨을 정하지 않아 임시로 1로 지정
+        if(actor.level() != 0)          //아직 관리자 레벨을 정하지 않아 임시로 1로 지정
         {
             throw new BusinessException(ErrorCode.FORBIDDEN_ADMIN);
         }


### PR DESCRIPTION
## #️⃣ 연관된 이슈 <!-- 이슈 번호를 적어주세요 -->
#123 

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
MenuController 내 관리자 권한 검증 로직을 BaseInitData 설정과 일치하도록 수정했습니다.

기존에는 관리자 레벨 = 1 기준으로 검증했으나, 초기 데이터에서는 관리자 레벨 = 0 / 사용자 레벨 = 1로 설정되어 있어 권한이 반대로 동작했습니다.

검증 조건을 actor.level() != 0 으로 변경하여 정상적으로 관리자 계정만 메뉴 생성/수정이 가능하도록 수정했습니다.

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
