### PR TITLE
feat:관리자 기능 구현 및 주문 조회 시 주소 보이게 구현

### DIFF
--- a/backend/src/main/java/com/backend/domain/order/controller/AdminOrderController.java
+++ b/backend/src/main/java/com/backend/domain/order/controller/AdminOrderController.java
@@ -41,8 +41,7 @@ public class AdminOrderController {
         UserDto actor = rq.getUser();
 
         //관리자 인증 로직 구현 예정
-        if(actor.level() != 1)
-        {
+        if (actor.level() != 1) {
             throw new BusinessException(ErrorCode.FORBIDDEN_ADMIN);
         }
 
@@ -57,7 +56,14 @@ public class AdminOrderController {
     public ResponseEntity<ApiResponse<OrderCreateResponse>> updateOrderStatus(
             @PathVariable Long orderId,
             @RequestBody @Valid OrderStatusUpdateRequest reqBody
-    ) {
+    ) throws Exception {
+        //쿠키에서 인증된 유저 가져오기
+        UserDto actor = rq.getUser();
+
+        //관리자 인증 로직 구현 예정
+        if (actor.level() != 1) {
+            throw new BusinessException(ErrorCode.FORBIDDEN_ADMIN);
+        }
         // 주문 상태 업데이트 로직 (예: 결제 완료, 배송 중 등)
         orderService.updateOrderStatus(orderId, reqBody.newStatus());
 

--- a/backend/src/main/java/com/backend/domain/order/controller/AdminOrderController.java
+++ b/backend/src/main/java/com/backend/domain/order/controller/AdminOrderController.java
@@ -1,6 +1,9 @@
 package com.backend.domain.order.controller;
 
+import com.backend.domain.order.dto.request.OrderStatusUpdateRequest;
 import com.backend.domain.order.dto.response.AdminOrderSummaryResponse;
+import com.backend.domain.order.dto.response.OrderCreateResponse;
+import com.backend.domain.order.entity.Orders;
 import com.backend.domain.order.service.AdminOrderService;
 import com.backend.domain.order.service.OrderService;
 import com.backend.domain.user.user.dto.UserDto;
@@ -11,13 +14,15 @@ import com.backend.global.response.ErrorCode;
 import com.backend.global.rq.Rq;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Optional;
 
 @Controller
 @RequestMapping("/api/admin/orders")
@@ -26,6 +31,7 @@ import java.util.List;
 public class AdminOrderController {
 
     private final AdminOrderService adminOrderService;
+    private final OrderService orderService;
     private final Rq rq;
 
     @GetMapping
@@ -35,9 +41,28 @@ public class AdminOrderController {
         UserDto actor = rq.getUser();
 
         //관리자 인증 로직 구현 예정
+        if(actor.level() != 1)
+        {
+            throw new BusinessException(ErrorCode.FORBIDDEN_ADMIN);
+        }
 
         // 전체 주문 조회
         List<AdminOrderSummaryResponse> summaries = adminOrderService.getAllOrdersForAdmin();
         return ResponseEntity.ok(ApiResponse.success(summaries));
+    }
+
+    @PutMapping("/{orderId}/status")
+    @Transactional
+    @Operation(summary = "주문 상태 업데이트", description = "주문의 상태를 업데이트합니다. (예: PAID, COMPLETED 등)")
+    public ResponseEntity<ApiResponse<OrderCreateResponse>> updateOrderStatus(
+            @PathVariable Long orderId,
+            @RequestBody @Valid OrderStatusUpdateRequest reqBody
+    ) {
+        // 주문 상태 업데이트 로직 (예: 결제 완료, 배송 중 등)
+        orderService.updateOrderStatus(orderId, reqBody.newStatus());
+
+        // 업데이트된 주문 정보 반환
+        Optional<Orders> updatedOrder = orderService.getOrderById(orderId);
+        return ResponseEntity.ok(ApiResponse.success(new OrderCreateResponse(updatedOrder)));
     }
 }

--- a/backend/src/main/java/com/backend/domain/order/controller/AdminOrderController.java
+++ b/backend/src/main/java/com/backend/domain/order/controller/AdminOrderController.java
@@ -49,26 +49,4 @@ public class AdminOrderController {
         List<AdminOrderSummaryResponse> summaries = adminOrderService.getAllOrdersForAdmin();
         return ResponseEntity.ok(ApiResponse.success(summaries));
     }
-
-    @PutMapping("/{orderId}/status")
-    @Transactional
-    @Operation(summary = "주문 상태 업데이트", description = "주문의 상태를 업데이트합니다. (예: PAID, COMPLETED 등)")
-    public ResponseEntity<ApiResponse<OrderCreateResponse>> updateOrderStatus(
-            @PathVariable Long orderId,
-            @RequestBody @Valid OrderStatusUpdateRequest reqBody
-    ) throws Exception {
-        //쿠키에서 인증된 유저 가져오기
-        UserDto actor = rq.getUser();
-
-        //관리자 인증 로직 구현 예정
-        if (actor.level() != 1) {
-            throw new BusinessException(ErrorCode.FORBIDDEN_ADMIN);
-        }
-        // 주문 상태 업데이트 로직 (예: 결제 완료, 배송 중 등)
-        orderService.updateOrderStatus(orderId, reqBody.newStatus());
-
-        // 업데이트된 주문 정보 반환
-        Optional<Orders> updatedOrder = orderService.getOrderById(orderId);
-        return ResponseEntity.ok(ApiResponse.success(new OrderCreateResponse(updatedOrder)));
-    }
 }

--- a/backend/src/main/java/com/backend/domain/order/controller/OrderController.java
+++ b/backend/src/main/java/com/backend/domain/order/controller/OrderController.java
@@ -1,11 +1,7 @@
 package com.backend.domain.order.controller;
 
 import com.backend.domain.order.dto.request.OrderCreateRequest;
-import com.backend.domain.order.dto.request.OrderStatusUpdateRequest;
-import com.backend.domain.order.dto.response.OrderCancelResponse;
-import com.backend.domain.order.dto.response.OrderCreateResponse;
-import com.backend.domain.order.dto.response.OrderDeleteResponse;
-import com.backend.domain.order.dto.response.OrderSummaryResponse;
+import com.backend.domain.order.dto.response.*;
 import com.backend.domain.order.entity.Orders;
 import com.backend.domain.order.service.OrderService;
 import com.backend.domain.user.user.dto.UserDto;
@@ -21,7 +17,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.Optional;
 
 @Controller
 @RequestMapping("/api/orders")
@@ -54,6 +49,17 @@ public class OrderController {
         //주문 조회 로직
         List<OrderSummaryResponse> summaries = orderService.getOrdersByUserId(actor.userId());
         return ResponseEntity.ok(ApiResponse.success(summaries));
+    }
+
+    @GetMapping("/{orderId}")
+    @Operation(summary = "주문 단건 조회", description = "특정 주문을 조회합니다.")
+    public ResponseEntity<ApiResponse<OrderSummaryResponse>> getOrderById(
+            @PathVariable Long orderId
+    ) throws Exception {
+        UserDto actor= rq.getUser();
+
+        OrderSummaryResponse order = orderService.getOrderByUserId(actor.userId(),orderId);
+        return ResponseEntity.ok(ApiResponse.success(order));
     }
 
     @PutMapping("/{orderId}/cancel")

--- a/backend/src/main/java/com/backend/domain/order/controller/OrderController.java
+++ b/backend/src/main/java/com/backend/domain/order/controller/OrderController.java
@@ -40,24 +40,9 @@ public class OrderController {
     ) throws Exception {
 
         UserDto actor = rq.getUser();
-        Orders order = orderService.createOrder(actor, request);
+        Orders order = orderService.createOrder(actor,request);
 
         return ResponseEntity.ok(ApiResponse.success(new OrderCreateResponse((order))));
-    }
-
-    @PutMapping("/{orderId}/status")
-    @Transactional
-    @Operation(summary = "주문 상태 업데이트", description = "주문의 상태를 업데이트합니다. (예: PAID, COMPLETED 등)")
-    public ResponseEntity<ApiResponse<OrderCreateResponse>> updateOrderStatus(
-            @PathVariable Long orderId,
-            @RequestBody @Valid OrderStatusUpdateRequest reqBody
-    ) {
-        // 주문 상태 업데이트 로직 (예: 결제 완료, 배송 중 등)
-        orderService.updateOrderStatus(orderId, reqBody.newStatus());
-
-        // 업데이트된 주문 정보 반환
-        Optional<Orders> updatedOrder = orderService.getOrderById(orderId);
-        return ResponseEntity.ok(ApiResponse.success(new OrderCreateResponse(updatedOrder)));
     }
 
     @GetMapping

--- a/backend/src/main/java/com/backend/domain/order/controller/OrderController.java
+++ b/backend/src/main/java/com/backend/domain/order/controller/OrderController.java
@@ -40,7 +40,7 @@ public class OrderController {
     ) throws Exception {
 
         UserDto actor = rq.getUser();
-        Orders order = orderService.createOrder(actor,request);
+        Orders order = orderService.createOrder(actor, request);
 
         return ResponseEntity.ok(ApiResponse.success(new OrderCreateResponse((order))));
     }

--- a/backend/src/main/java/com/backend/domain/order/controller/OrderController.java
+++ b/backend/src/main/java/com/backend/domain/order/controller/OrderController.java
@@ -1,6 +1,7 @@
 package com.backend.domain.order.controller;
 
 import com.backend.domain.order.dto.request.OrderCreateRequest;
+import com.backend.domain.order.dto.request.OrderStatusUpdateRequest;
 import com.backend.domain.order.dto.response.*;
 import com.backend.domain.order.entity.Orders;
 import com.backend.domain.order.service.OrderService;
@@ -17,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Optional;
 
 @Controller
 @RequestMapping("/api/orders")
@@ -95,5 +97,23 @@ public class OrderController {
         );
 
         return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PutMapping("/{orderId}/status")
+    @Transactional
+    @Operation(summary = "주문 상태 업데이트", description = "주문의 상태를 업데이트합니다. (예: PAID, COMPLETED 등)")
+    public ResponseEntity<ApiResponse<OrderCreateResponse>> updateOrderStatus(
+            @PathVariable Long orderId,
+            @RequestBody @Valid OrderStatusUpdateRequest reqBody
+    ) throws Exception {
+        //쿠키에서 인증된 유저 가져오기
+        UserDto actor = rq.getUser();
+
+        // 주문 상태 업데이트 로직 (예: 결제 완료, 배송 중 등)
+        orderService.updateOrderStatus(orderId, reqBody.newStatus());
+
+        // 업데이트된 주문 정보 반환
+        Optional<Orders> updatedOrder = orderService.getOrderById(orderId);
+        return ResponseEntity.ok(ApiResponse.success(new OrderCreateResponse(updatedOrder)));
     }
 }

--- a/backend/src/main/java/com/backend/domain/order/dto/request/OrderCreateRequest.java
+++ b/backend/src/main/java/com/backend/domain/order/dto/request/OrderCreateRequest.java
@@ -7,6 +7,7 @@ import java.util.List;
 // 주문 생성 시 요청 DTO
 public record OrderCreateRequest(
         @Min(0) int amount,
+        Long addressId,
         @NotEmpty List<OrderDetailsCreateRequest> items
 ) {
 }

--- a/backend/src/main/java/com/backend/domain/order/dto/response/AdminOrderSummaryResponse.java
+++ b/backend/src/main/java/com/backend/domain/order/dto/response/AdminOrderSummaryResponse.java
@@ -12,4 +12,5 @@ public record AdminOrderSummaryResponse(
         String userPhone,
         String address,
         List<OrderSummaryDetailResponse> items
-) {}
+) {
+}

--- a/backend/src/main/java/com/backend/domain/order/dto/response/OrderDetailsCreateResponse.java
+++ b/backend/src/main/java/com/backend/domain/order/dto/response/OrderDetailsCreateResponse.java
@@ -16,7 +16,7 @@ public record OrderDetailsCreateResponse(
     public OrderDetailsCreateResponse(OrderDetails details) {
         this(
                 details.getOrderItemId(),
-                details.getMenu().getMenuId(), // Menu 엔티티에 getMenuId()가 있다고 가정
+                details.getMenu().getMenuId(),
                 details.getMenuName(),
                 details.getQuantity(),
                 details.getOrderPrice()

--- a/backend/src/main/java/com/backend/domain/order/dto/response/OrderSummaryDetailResponse.java
+++ b/backend/src/main/java/com/backend/domain/order/dto/response/OrderSummaryDetailResponse.java
@@ -4,4 +4,5 @@ public record OrderSummaryDetailResponse(
         String productName,   // 상품명
         int quantity,         // 상품 개수
         int orderPrice        // 결제 금액 (해당 상품 총 금액)
-) { }
+) {
+}

--- a/backend/src/main/java/com/backend/domain/order/dto/response/OrderSummaryResponse.java
+++ b/backend/src/main/java/com/backend/domain/order/dto/response/OrderSummaryResponse.java
@@ -10,4 +10,5 @@ public record OrderSummaryResponse(
         String status,             // 주문 상태
         String address,            // 주소
         List<OrderSummaryDetailResponse> items  // 주문 상세 목록
-) {}
+) {
+}

--- a/backend/src/main/java/com/backend/domain/order/dto/response/OrderSummaryResponse.java
+++ b/backend/src/main/java/com/backend/domain/order/dto/response/OrderSummaryResponse.java
@@ -8,6 +8,6 @@ public record OrderSummaryResponse(
         LocalDateTime orderTime,   // 주문 일시
         int orderAmount,           // 총 금액
         String status,             // 주문 상태
-        String address,            // 주소 (Address 엔티티의 필드 합쳐서 String 처리)
+        String address,            // 주소
         List<OrderSummaryDetailResponse> items  // 주문 상세 목록
 ) {}

--- a/backend/src/main/java/com/backend/domain/order/entity/OrderDetails.java
+++ b/backend/src/main/java/com/backend/domain/order/entity/OrderDetails.java
@@ -39,7 +39,7 @@ public class OrderDetails {
     @Column(length = 100, nullable = false)
     private String menuName;
 
-    public OrderDetails(Menu menu, int quantity, int orderPrice , String menuName) {
+    public OrderDetails(Menu menu, int quantity, int orderPrice, String menuName) {
         this.menu = menu;
         this.quantity = quantity;
         this.orderPrice = orderPrice;

--- a/backend/src/main/java/com/backend/domain/order/entity/Orders.java
+++ b/backend/src/main/java/com/backend/domain/order/entity/Orders.java
@@ -44,6 +44,7 @@ public class Orders extends BaseEntity {
 
     //     Address 엔티티와의 관계 (다대일) - 주소 도메인이 만들어지면 연결
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "address_id")
     private Address address;
 
     //     Payment 엔티티와의 관계 (일대일) - 결제 도메인이 만들어지면 연결
@@ -58,9 +59,10 @@ public class Orders extends BaseEntity {
         }
     }
 
-    public Orders(Users user, int calculatedTotal, OrderStatus orderStatus) {
+    public Orders(Users user, int orderAmount, OrderStatus orderStatus, Address address) {
         this.user = user;
-        this.orderAmount = calculatedTotal;
+        this.orderAmount = orderAmount;
         this.orderStatus = orderStatus;
+        this.address = address;
     }
 }

--- a/backend/src/main/java/com/backend/domain/order/service/OrderService.java
+++ b/backend/src/main/java/com/backend/domain/order/service/OrderService.java
@@ -11,6 +11,9 @@ import com.backend.domain.order.entity.OrderDetails;
 import com.backend.domain.order.entity.OrderStatus;
 import com.backend.domain.order.entity.Orders;
 import com.backend.domain.order.repository.OrderRepository;
+import com.backend.domain.user.address.dto.AddressDto;
+import com.backend.domain.user.address.entity.Address;
+import com.backend.domain.user.address.repository.AddressRepository;
 import com.backend.domain.user.user.dto.UserDto;
 import com.backend.domain.user.user.entity.Users;
 import com.backend.domain.user.user.repository.UserRepository;
@@ -33,6 +36,7 @@ public class OrderService {
     private final OrderRepository orderRepository;
     private final UserRepository usersRepository;
     private final MenuRepository menuRepository;
+    private final AddressRepository addressRepository;
     private final CartService cartService;
 
     @Transactional
@@ -41,7 +45,11 @@ public class OrderService {
         Users user = usersRepository.findById(actor.userId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_MEMBER));
 
-        // 2. 주문 항목 처리
+        // 2 주소 가져오기(이미 등록된 주소 중 하나)
+        Address address = addressRepository.findById(request.addressId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_ADDRESS));
+
+        // 3. 주문 항목 처리
         List<OrderDetails> orderDetails = new ArrayList<>();
         int calculatedTotal = 0;
 
@@ -65,22 +73,22 @@ public class OrderService {
             orderDetails.add(detail);
         }
 
-        // 3. 금액 검증
+        // 4. 금액 검증
         if (calculatedTotal != request.amount()) {
             throw new BusinessException(ErrorCode.INVALID_ORDER_AMOUNT);
         }
 
-        // 4. 주문 엔티티 생성 (Users 엔티티 사용)
-        Orders order = new Orders(user, calculatedTotal, OrderStatus.CREATED);
+        // 5. 주문 엔티티 생성 (Users 엔티티 사용)
+        Orders order = new Orders(user, calculatedTotal, OrderStatus.CREATED, address);
         order.addOrderDetails(orderDetails);
 
-        // 5. 장바구니에서 해당 아이템들 삭제
+        // 6. 장바구니에서 해당 아이템들 삭제
         List<Long> orderedMenuIds = orderDetails.stream()
                 .map(d -> d.getMenu().getMenuId())
                 .toList();
         cartService.deleteOrderedItems(actor, orderedMenuIds);
 
-        // 6. 주문 저장
+        // 7. 주문 저장
         return orderRepository.save(order);
     }
 
@@ -131,20 +139,28 @@ public class OrderService {
         }
 
         return orders.stream()
-                .map(order -> new OrderSummaryResponse(
-                        order.getOrderId(),
-                        order.getCreateDate(),
-                        order.getOrderAmount(),
-                        order.getOrderStatus().name(),
-                        order.getAddress() != null ? order.getAddress().toString() : null,
-                        order.getOrderDetails().stream()
-                                .map(detail -> new OrderSummaryDetailResponse(
-                                        detail.getMenu().getName(),
-                                        detail.getQuantity(),
-                                        detail.getOrderPrice()
-                                ))
-                                .toList()
-                ))
+                .map(order -> {
+                    AddressDto addressDto = order.getAddress() != null
+                            ? new AddressDto(order.getAddress())
+                            : null;
+
+                    return new OrderSummaryResponse(
+                            order.getOrderId(),
+                            order.getCreateDate(),
+                            order.getOrderAmount(),
+                            order.getOrderStatus().name(),
+                            addressDto != null
+                                    ? addressDto.address() + " " + addressDto.addressDetail()
+                                    : null,
+                            order.getOrderDetails().stream()
+                                    .map(detail -> new OrderSummaryDetailResponse(
+                                            detail.getMenu().getName(),
+                                            detail.getQuantity(),
+                                            detail.getOrderPrice()
+                                    ))
+                                    .toList()
+                    );
+                })
                 .toList();
     }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈 <!-- 이슈 번호를 적어주세요 -->
#126 
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
관리자 인증 로직 구현했고 
주문 상태 업데이트 API는 관리자만 사용할 것 같아 `AdminOrderController`로 옮겼습니다. 
`http://localhost:8080/api/admin/orders/1/status` 로 바꿨습니다.
주문 생성했을 때 
```
{
  "amount": 50000,
   "addressId": 1,
  "items": [
    { "productId": 1, "menuName": "콜롬비아", "quantity": 2, "orderPrice": 50000 }
  ]
}
```
로 addressId로 주소 받아올 수 있게 변경했습니다.

인증된 사용자가 개별 주문을 조회 할 수 있는 기능 구현했습니다.
