### PR TITLE
refactor: 결제 요청 시 성공/승인에 따른 상태 변화 코드 수정

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -37,6 +37,8 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
     implementation 'me.paulschwarz:spring-dotenv:4.0.0'
+    implementation 'org.springframework.retry:spring-retry'
+    implementation 'org.springframework:spring-aspects'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/backend/BackendApplication.java
+++ b/backend/src/main/java/com/backend/BackendApplication.java
@@ -3,9 +3,11 @@ package com.backend;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.retry.annotation.EnableRetry;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableRetry
 public class BackendApplication {
 
     public static void main(String[] args) {

--- a/backend/src/main/java/com/backend/domain/payment/entity/Payment.java
+++ b/backend/src/main/java/com/backend/domain/payment/entity/Payment.java
@@ -50,6 +50,10 @@ public class Payment extends BaseEntity {
         this.paymentStatus = PaymentStatus.COMPLETED;
     }
 
+    public void fail() {
+        this.paymentStatus = PaymentStatus.FAILED;
+    }
+
     public void cancel() {
         if(this.paymentStatus == PaymentStatus.CANCELED) {
             throw new BusinessException(ErrorCode.PAYMENT_ALREADY_CANCELLED);

--- a/backend/src/main/java/com/backend/domain/payment/service/PaymentFactory.java
+++ b/backend/src/main/java/com/backend/domain/payment/service/PaymentFactory.java
@@ -1,0 +1,22 @@
+package com.backend.domain.payment.service;
+
+import com.backend.domain.order.entity.Orders;
+import com.backend.domain.payment.dto.request.PaymentCreateRequest;
+import com.backend.domain.payment.entity.Payment;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PaymentFactory {
+    // 성공/실패 시 각각의 결과를 담은 객체 생성
+    public Payment createCompletedPayment(PaymentCreateRequest request, Orders orders) {
+        Payment payment = request.createPayment(orders);
+        payment.complete();
+        return payment;
+    }
+
+    public Payment createFailedPayment(PaymentCreateRequest request, Orders orders) {
+        Payment payment = request.createPayment(orders);
+        payment.fail();
+        return payment;
+    }
+}

--- a/backend/src/main/java/com/backend/domain/payment/service/PaymentProcessor.java
+++ b/backend/src/main/java/com/backend/domain/payment/service/PaymentProcessor.java
@@ -1,0 +1,8 @@
+package com.backend.domain.payment.service;
+
+import com.backend.domain.payment.dto.request.PaymentCreateRequest;
+
+public interface PaymentProcessor {
+    // 결제 처리 전략 정의
+    boolean process(PaymentCreateRequest request);
+}

--- a/backend/src/main/java/com/backend/domain/payment/service/PaymentRetry.java
+++ b/backend/src/main/java/com/backend/domain/payment/service/PaymentRetry.java
@@ -1,0 +1,78 @@
+package com.backend.domain.payment.service;
+
+import com.backend.domain.order.entity.Orders;
+import com.backend.domain.order.repository.OrderRepository;
+import com.backend.domain.order.service.OrderService;
+import com.backend.domain.payment.dto.request.PaymentCreateRequest;
+import com.backend.domain.payment.dto.response.PaymentCreateResponse;
+import com.backend.domain.payment.entity.Payment;
+import com.backend.domain.payment.repository.PaymentRepository;
+import com.backend.global.exception.BusinessException;
+import com.backend.global.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PaymentRetry {
+    private final PaymentProcessor paymentProcessor;
+    private final PaymentFactory paymentFactory;
+    private final PaymentRepository paymentRepository;
+    private final OrderRepository orderRepository;
+    private final OrderService orderService;
+
+    /**
+     * 재시도 로직
+     * 결제 처리기 (PaymentProcessor) 호출 실패 시 최대 2회 재시도
+     * BusinessException, RuntimeException 발생 시 재시도
+     * IllegalArgumentException은 재시도하지 않음 (잘못된 파라미터는 재시도해도 의미 없음)
+     * */
+    @Retryable(
+            retryFor = {BusinessException.class, RuntimeException.class},
+            noRetryFor = {IllegalArgumentException.class},
+            maxAttempts = 2,
+            backoff = @Backoff(delay = 1000)
+    )
+    public PaymentCreateResponse processPaymentWithRetry(PaymentCreateRequest request, Orders orders) {
+        boolean paymentSuccess = paymentProcessor.process(request);
+
+        if (!paymentSuccess) {
+            throw new BusinessException(ErrorCode.PAYMENT_FAILED);
+        }
+
+        Payment payment = paymentFactory.createCompletedPayment(request, orders);
+        Payment savePayment = paymentRepository.save(payment);
+
+        updateOrderForSuccessfulPayment(orders, savePayment);
+
+        return new PaymentCreateResponse(savePayment);
+    }
+
+    /**
+     * 모든 재시도 실패 시 실행되는 복구 메서드
+     * - @Retryable 메서드의 모든 재시도가 실패했을 때 자동 호출
+     */
+    @Recover
+    public PaymentCreateResponse recoverFromPaymentFailure(Exception ex,
+                                                           PaymentCreateRequest request,
+                                                           Orders orders) {
+        Payment failedPayment = paymentFactory.createFailedPayment(request, orders);
+        paymentRepository.save(failedPayment);
+
+        orders.setPayment(failedPayment);
+        orderRepository.save(orders);
+
+        throw new BusinessException(ErrorCode.PAYMENT_FAILED);
+    }
+
+    // 결제 성공 시 주문 상태 업데이트
+    private void updateOrderForSuccessfulPayment(Orders orders, Payment payment) {
+        orders.setPayment(payment);
+        orderService.updateOrderStatus(orders.getOrderId(), "PAID");
+    }
+}

--- a/backend/src/main/java/com/backend/domain/payment/service/PaymentService.java
+++ b/backend/src/main/java/com/backend/domain/payment/service/PaymentService.java
@@ -1,8 +1,8 @@
 package com.backend.domain.payment.service;
 
-import com.backend.domain.order.entity.OrderStatus;
 import com.backend.domain.order.entity.Orders;
 import com.backend.domain.order.repository.OrderRepository;
+import com.backend.domain.order.service.OrderService;
 import com.backend.domain.payment.dto.request.PaymentCreateRequest;
 import com.backend.domain.payment.dto.response.PaymentCancelResponse;
 import com.backend.domain.payment.dto.response.PaymentCreateResponse;
@@ -26,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class PaymentService {
     private final OrderRepository orderRepository;
     private final PaymentRepository paymentRepository;
+    private final OrderService orderService;
 
     // 결제 요청
     @Transactional
@@ -46,16 +47,69 @@ public class PaymentService {
             throw new BusinessException(ErrorCode.PAYMENT_ALREADY_COMPLETED);
         }
 
+        /**
+         * 결제 시도 로직: 성공 시 적재, 실패 시 재시도 1회
+         * */
+        int maxRetries = 2;
+        Exception lastException = null;
+        for(int attempt = 1; attempt <= maxRetries; attempt++){
+            try {
+                boolean paymentSuccess = processPayment(request);
+                if(paymentSuccess) {
+                    Payment payment = createCompletedPayment(request, orders);
+                    Payment savePayment = paymentRepository.save(payment);
+
+                    updateOrderForSuccessfulPayment(orders, savePayment);
+
+                    return new PaymentCreateResponse(savePayment);
+                }
+            } catch (Exception e) {
+                lastException = e;
+                log.error("결제 시도 중 오류: error={}", e.getMessage());
+            }
+        }
+
+        /**
+         * 결제 처리가 최종 실패했을 경우: 실패 데이터 적재
+         * */
+        Payment failedPayment = createFailedPayment(request, orders);
+        paymentRepository.save(failedPayment);
+
+        throw new BusinessException(ErrorCode.PAYMENT_FAILED);
+    }
+
+    // 결제 처리 (결제 성공 여부 확인)
+    private boolean processPayment(PaymentCreateRequest request){
+        try {
+            /*
+            * 결제 실패 시뮬레이션을 위한 확률, 70% 성공률이라고 가정
+            * */
+            boolean success = Math.random() > 0.3;
+
+            return success;
+        } catch (Exception e){
+            return false;
+        }
+    }
+
+    // 결제 성공 시 결제 상태가 COMPLETE 상태의 Payment 생성
+    private Payment createCompletedPayment(PaymentCreateRequest request, Orders orders){
         Payment payment = request.createPayment(orders);
-        Payment savePayment = paymentRepository.save(payment);
-
-        orders.setPayment(savePayment);
-        orders.setOrderStatus(OrderStatus.PAID);
-        orderRepository.save(orders);
-
         payment.complete();
+        return payment;
+    }
 
-        return new PaymentCreateResponse(savePayment);
+    // 결제 실패 시 결제 상태가 FAILD 상태인 Payment 생성
+    private Payment createFailedPayment(PaymentCreateRequest request, Orders orders){
+        Payment payment = request.createPayment(orders);
+        payment.fail();
+        return payment;
+    }
+
+    // 결제 성공 시 주문 상태 업데이트
+    private void updateOrderForSuccessfulPayment(Orders orders, Payment payment) {
+        orders.setPayment(payment);
+        orderService.updateOrderStatus(orders.getOrderId(), "PAID");
     }
 
     // 결제 단건 조회

--- a/backend/src/main/java/com/backend/domain/payment/service/RandomPaymentProcessor.java
+++ b/backend/src/main/java/com/backend/domain/payment/service/RandomPaymentProcessor.java
@@ -1,0 +1,15 @@
+package com.backend.domain.payment.service;
+
+import com.backend.domain.payment.dto.request.PaymentCreateRequest;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RandomPaymentProcessor implements PaymentProcessor {
+    @Override
+    public boolean process(PaymentCreateRequest request) {
+        /*
+         * 결제 실패 시뮬레이션: 70% 성공률
+         */
+        return Math.random() > 0.3;
+    }
+}

--- a/backend/src/test/java/com/backend/domain/payment/service/PaymentServiceTest.java
+++ b/backend/src/test/java/com/backend/domain/payment/service/PaymentServiceTest.java
@@ -1,0 +1,159 @@
+package com.backend.domain.payment.service;
+
+import com.backend.domain.order.entity.OrderStatus;
+import com.backend.domain.order.entity.Orders;
+import com.backend.domain.order.repository.OrderRepository;
+import com.backend.domain.order.service.OrderService;
+import com.backend.domain.payment.dto.request.PaymentCreateRequest;
+import com.backend.domain.payment.dto.response.PaymentCreateResponse;
+import com.backend.domain.payment.entity.Payment;
+import com.backend.domain.payment.entity.PaymentMethod;
+import com.backend.domain.payment.entity.PaymentStatus;
+import com.backend.domain.payment.repository.PaymentRepository;
+import com.backend.domain.user.address.entity.Address;
+import com.backend.domain.user.address.repository.AddressRepository;
+import com.backend.domain.user.user.dto.UserDto;
+import com.backend.domain.user.user.entity.Users;
+import com.backend.domain.user.user.repository.UserRepository;
+import com.backend.global.exception.BusinessException;
+import com.backend.global.response.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@Transactional
+class PaymentServiceTest {
+
+    @Autowired
+    private OrderRepository orderRepository;
+
+    @Autowired
+    private PaymentRepository paymentRepository;
+
+    @Autowired
+    private OrderService orderService;
+
+    @Autowired
+    private PaymentService paymentService;
+
+    @Autowired
+    private PaymentFactory paymentFactory;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private AddressRepository addressRepository;
+
+    // === 핵심: PaymentProcessor를 MockBean으로 교체 ===
+    @MockBean
+    private PaymentProcessor paymentProcessor;
+
+    @Test
+    @DisplayName("결제 성공 테스트 - 단순화 (MockProcessor 사용)")
+    void createPayment_Success_Simple() {
+        // Given
+        Users savedUser = userRepository.save(
+                new Users("test@example.com", "password123", "010-1234-5678", 1)
+        );
+
+        Address savedAddress = addressRepository.save(
+                new Address(savedUser, "서울시 강남구 테헤란로", "123번길 456호", "12345")
+        );
+
+        Orders savedOrder = orderRepository.save(
+                new Orders(savedUser, 10000, OrderStatus.CREATED, savedAddress)
+        );
+
+        PaymentCreateRequest paymentRequest = new PaymentCreateRequest(
+                savedOrder.getOrderId(), 10000, PaymentMethod.CARD
+        );
+        UserDto userDto = new UserDto(savedUser);
+
+        // 무조건 성공하도록
+        when(paymentProcessor.process(any())).thenReturn(true);
+
+        // When
+        PaymentCreateResponse response = paymentService.createPayment(paymentRequest, userDto);
+
+        // Then
+        Orders updatedOrder = orderRepository.findById(savedOrder.getOrderId()).orElseThrow();
+
+        assertThat(response).isNotNull();
+        assertThat(response.paymentId()).isNotNull();
+        assertThat(response.paymentAmount()).isEqualTo(10000);
+        assertThat(response.paymentMethod()).isEqualTo(PaymentMethod.CARD);
+
+        // 결제 성공 상태 검증
+        assertThat(response.paymentStatus()).isEqualTo(PaymentStatus.COMPLETED);
+        assertThat(updatedOrder.getOrderStatus()).isEqualTo(OrderStatus.PAID);
+        assertThat(updatedOrder.getPayment()).isNotNull();
+
+        // 실제 저장된 Payment 객체의 상태도 확인
+        Payment savedPayment = paymentRepository.findById(response.paymentId()).orElseThrow();
+        assertThat(savedPayment.getPaymentStatus()).isEqualTo(PaymentStatus.COMPLETED);
+    }
+
+    @Test
+    @DisplayName("결제 실패 테스트")
+    void createPayment_Failure_Simple() {
+        // Given
+        Users savedUser = userRepository.save(
+                new Users("fail@example.com", "password123", "010-9876-5432", 1)
+        );
+
+        Address savedAddress = addressRepository.save(
+                new Address(savedUser, "서울시 강남구 테헤란로", "999번길 111호", "54321")
+        );
+
+        Orders savedOrder = orderRepository.save(
+                new Orders(savedUser, 20000, OrderStatus.CREATED, savedAddress)
+        );
+
+        PaymentCreateRequest paymentRequest = new PaymentCreateRequest(
+                savedOrder.getOrderId(), 20000, PaymentMethod.CARD
+        );
+        UserDto userDto = new UserDto(savedUser);
+
+        // 무조건 실패하도록
+        when(paymentProcessor.process(any())).thenReturn(false);
+
+        // When & Then
+        BusinessException ex = assertThrows(
+                BusinessException.class,
+                () -> paymentService.createPayment(paymentRequest, userDto)
+        );
+
+        // 예외 객체와 ErrorCode 검증
+        assertThat(ex).isNotNull();
+        assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PAYMENT_FAILED);
+
+        // 디버깅용 출력
+        System.out.println("예외 클래스 = " + ex.getClass().getName());
+        System.out.println("ErrorCode = " + ex.getErrorCode());
+
+        // DB 상태 검증
+        List<Payment> payments = paymentRepository.findAll();
+        assertThat(payments).isNotEmpty();
+        assertThat(payments.get(0).getPaymentStatus()).isEqualTo(PaymentStatus.FAILED);
+
+        Orders updatedOrder = orderRepository.findById(savedOrder.getOrderId()).orElseThrow();
+        assertThat(updatedOrder.getOrderStatus()).isEqualTo(OrderStatus.CREATED);
+        assertThat(updatedOrder.getPayment()).isNotNull();
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈 <!-- 이슈 번호를 적어주세요 -->
#130 

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
결제 요청 시 성공/승인에 따른 상태 변화 코드 수정했습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
12c3cdf:  Payment에 결제 실패 비즈니스 로직 추가
745c5dc: 기존의 결제 요청 코드에서 성공, 실패 시 각각 다른 상태 값을 가질 수 있도록 수정했습니다.
1. 결제 요청은 총 2회 시도하며, 모든 시도 실패 시 결제 상태가 FAILED인 결제 데이터를 생성하도록 리팩토링했습니다.
-> 주문의 경우, 실패한 결제 정보가 연결되지만 상태는 CREATED를 유지합니다.
-> **[종수 님 확인 사항] 결제 성공 시에만 주문 상태가 PAID로 변경되게 구현했습니다.**

2fea0d4: createPayment 메서드가 여러 개의 책임을 갖고 있는 것 같아 로직 분리했습니다.
d845ec2: 기존에 for문으로 작성했던 재시도 로직을 **Spring retryable 라이브러리** 이용해 수정했습니다.
32f6468: 결제 생성 시 성공, 실패를 기준으로 테스트 코드 작성했습니다.

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
현재 구현된 결제는 70%의 성공 확률을 갖도록 설계하였으며, 
해당 부분은 mock 결제에서 결제 실패 시 로직을 설계하기 위해 임의로 작성된 코드이기 때문에 PG사와 같은 실 결제 서비스 도입 시 변경될 예정입니다.