### PR TITLE
refactor: 주문-결제 취소, 삭제 연동

### DIFF
--- a/backend/src/main/java/com/backend/domain/payment/service/PaymentService.java
+++ b/backend/src/main/java/com/backend/domain/payment/service/PaymentService.java
@@ -18,6 +18,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
@@ -70,7 +71,7 @@ public class PaymentService {
         return new PaymentInquiryResponse(payment);
     }
 
-    // 결제 단건 취소
+    // 결제 단건 취소 - controller
     @Transactional
     public PaymentCancelResponse cancelPayment(@Valid Long paymentId, UserDto currentUser) {
         if(paymentId == null || paymentId <= 0) {
@@ -93,7 +94,19 @@ public class PaymentService {
         return new PaymentCancelResponse(payment);
     }
 
-    // 취소된 결제 내역 삭제
+    // 결제 단건 취소 - orderService 연동
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void cancelPaymentByOrder(Orders order, UserDto user) {
+        Payment payment = order.getPayment();
+
+        if (payment.getPaymentStatus() != PaymentStatus.COMPLETED) {
+            throw new BusinessException(ErrorCode.PAYMENT_NOT_CANCELLABLE);
+        }
+
+        payment.cancel();
+    }
+
+    // 취소된 결제 내역 삭제 - controller
     @Transactional
     public void deletePayment(@Valid Long paymentId, UserDto currentUser) {
         if(paymentId == null || paymentId <= 0) {
@@ -112,5 +125,18 @@ public class PaymentService {
         }
 
         paymentRepository.delete(payment);
+    }
+
+    // 취소된 결제 내역 삭제 - orderService 연동
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void deletePaymentByOrder(Orders order, UserDto user) {
+        Payment payment = order.getPayment();
+
+        if (payment.getPaymentStatus() != PaymentStatus.CANCELED) {
+            throw new BusinessException(ErrorCode.PAYMENT_DELETE_FAILED);
+        }
+
+        paymentRepository.delete(payment);
+        order.setPayment(null);
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈 <!-- 이슈 번호를 적어주세요 -->
Closed #130 

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
주문 취소, 주문 삭제가 마무리되기 전 결제 삭제, 결제 취소를 선제적으로 진행하도록 수정했습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
d645661: 주문 취소, 주문 삭제가 진행되기 전에 결제 취소, 결제 삭제가 먼저 진행

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
기존에 작성했던 서비스 로직은 건들지 않고, 새로운 메서드로 작성했기 때문에 controller를 통해 개별 요청은 여전히 가능합니다.
종수 님 확인해 주세요!
