### PR TITLE
feature : 주문/결제 페이지 구성

### DIFF
--- a/backend/src/main/java/com/backend/domain/order/dto/response/AdminOrderSummaryResponse.java
+++ b/backend/src/main/java/com/backend/domain/order/dto/response/AdminOrderSummaryResponse.java
@@ -11,6 +11,7 @@ public record AdminOrderSummaryResponse(
         String userEmail,
         String userPhone,
         String address,
+        Long paymentId,
         List<OrderSummaryDetailResponse> items
 ) {
 }

--- a/backend/src/main/java/com/backend/domain/order/dto/response/OrderSummaryDetailResponse.java
+++ b/backend/src/main/java/com/backend/domain/order/dto/response/OrderSummaryDetailResponse.java
@@ -3,6 +3,7 @@ package com.backend.domain.order.dto.response;
 public record OrderSummaryDetailResponse(
         String productName,   // 상품명
         int quantity,         // 상품 개수
-        int orderPrice        // 결제 금액 (해당 상품 총 금액)
+        int orderPrice,       // 결제 금액 (해당 상품 총 금액),
+        String imageUrl
 ) {
 }

--- a/backend/src/main/java/com/backend/domain/order/service/AdminOrderService.java
+++ b/backend/src/main/java/com/backend/domain/order/service/AdminOrderService.java
@@ -48,11 +48,13 @@ public class AdminOrderService {
                             addressDto != null
                                     ? addressDto.address() + " " + addressDto.addressDetail()
                                     : null,
+                            order.getPayment().getPaymentId(),
                             order.getOrderDetails().stream()
                                     .map(detail -> new OrderSummaryDetailResponse(
                                             detail.getMenu().getName(),
                                             detail.getQuantity(),
-                                            detail.getOrderPrice()
+                                            detail.getOrderPrice(),
+                                            detail.getMenu() != null ? detail.getMenu().getImageUrl() : null
                                     ))
                                     .toList()
                     );

--- a/backend/src/main/java/com/backend/domain/order/service/OrderService.java
+++ b/backend/src/main/java/com/backend/domain/order/service/OrderService.java
@@ -159,7 +159,8 @@ public class OrderService {
                                     .map(detail -> new OrderSummaryDetailResponse(
                                             detail.getMenu().getName(),
                                             detail.getQuantity(),
-                                            detail.getOrderPrice()
+                                            detail.getOrderPrice(),
+                                            detail.getMenu().getImageUrl()
                                     ))
                                     .toList()
                     );
@@ -234,7 +235,8 @@ public class OrderService {
                 .map(od -> new OrderSummaryDetailResponse(
                         od.getMenu().getName(),
                         od.getQuantity(),
-                        od.getOrderPrice()
+                        od.getOrderPrice(),
+                        od.getMenu() != null ? od.getMenu().getImageUrl() : null
                 ))
                 .toList();
 

--- a/frontend/src/app/orders/admin/page.tsx
+++ b/frontend/src/app/orders/admin/page.tsx
@@ -2,11 +2,13 @@
 
 import { useEffect, useState } from "react"
 import { fetchApi } from "@/lib/client"
+import Link from "next/link"
 
 type OrderItem = {
   productName: string
   quantity: number
   orderPrice: number
+  imageUrl?: string
 }
 
 type AdminOrder = {
@@ -17,6 +19,7 @@ type AdminOrder = {
   userEmail: string
   userPhone: string
   address: string
+  paymentId?: number
   items: OrderItem[]
 }
 
@@ -103,25 +106,57 @@ export default function AdminOrdersPage() {
                 </p>
 
                 {/* 상품 */}
-                <ul className="mt-2 text-sm text-gray-700 space-y-1">
+                <ul className="mt-2 text-sm text-gray-700 space-y-2">
                   {order.items.map((item, idx) => (
-                    <li key={idx} className="flex justify-between">
-                      <span>
-                        {item.productName} ({item.quantity}개)
+                    <li
+                      key={idx}
+                      className="flex items-center gap-3 border-b pb-2"
+                    >
+                      {/* 이미지 */}
+                      {item.imageUrl && (
+                        <img
+                          src={item.imageUrl}
+                          alt={item.productName}
+                          className="w-12 h-12 object-cover rounded"
+                        />
+                      )}
+                      {/* 상품명 + 수량 */}
+                      <div className="flex-1">
+                        <span className="font-medium">{item.productName}</span>{" "}
+                        <span className="text-gray-500">
+                          ({item.quantity}개)
+                        </span>
+                      </div>
+                      {/* 금액 */}
+                      <span className="font-semibold">
+                        {item.orderPrice.toLocaleString()}원
                       </span>
-                      <span>{item.orderPrice.toLocaleString()}원</span>
                     </li>
                   ))}
                 </ul>
 
                 {/* 버튼 */}
                 <div className="flex gap-2 mt-4">
-                  <button
-                    onClick={() => updateStatus(order.orderId, "PAID")}
-                    className="flex-1 border rounded py-2 text-sm bg-blue-50 hover:bg-blue-100"
-                  >
-                    결제 완료(PAID)
-                  </button>
+                  {/* 결제 내역 보기 */}
+                  {order.paymentId ? (
+                    <Link
+                      href={`/payment/${order.paymentId}`}
+                      className="flex-1"
+                    >
+                      <button className="w-full border rounded py-2 text-sm bg-blue-50 hover:bg-blue-100 text-center">
+                        결제 내역 보기
+                      </button>
+                    </Link>
+                  ) : (
+                    <button
+                      disabled
+                      className="flex-1 w-full border rounded py-2 text-sm bg-gray-200 text-gray-400 cursor-not-allowed"
+                    >
+                      결제 내역 없음
+                    </button>
+                  )}
+
+                  {/* 배송 처리 */}
                   <button
                     onClick={() => updateStatus(order.orderId, "COMPLETED")}
                     className="flex-1 border rounded py-2 text-sm bg-green-50 hover:bg-green-100"

--- a/frontend/src/app/orders/page.tsx
+++ b/frontend/src/app/orders/page.tsx
@@ -8,6 +8,7 @@ type OrderItem = {
   productName: string
   quantity: number
   orderPrice: number
+  imageUrl?: string
 }
 
 type Order = {
@@ -119,8 +120,8 @@ export default function OrdersPage() {
                   </h2>
                   <span
                     className={`text-sm border px-2 py-0.5 rounded ${order.status === "CANCELED"
-                        ? "text-red-600 border-red-600"
-                        : "text-green-600 border-green-600"
+                      ? "text-red-600 border-red-600"
+                      : "text-green-600 border-green-600"
                       }`}
                   >
                     {order.status}
@@ -137,16 +138,32 @@ export default function OrdersPage() {
                   배송주소: {order.address}
                 </p>
 
-                <ul className="mt-2 text-sm text-gray-600 space-y-1">
+                <ul className="mt-2 text-sm text-gray-600 space-y-3">
                   {order.items.map((item, idx) => (
-                    <li key={idx} className="flex justify-between">
-                      <span>
-                        {item.productName} ({item.quantity}개)
-                      </span>
-                      <span>{item.orderPrice.toLocaleString()}원</span>
+                    <li
+                      key={`${order.orderId}-${idx}`}
+                      className="flex items-center gap-4 py-2 border-b">
+                      {/* 상품 이미지 */}
+                      <img
+                        src={item.imageUrl}
+                        alt={item.productName}
+                        className="w-16 h-16 object-cover rounded"
+                      />
+
+                      {/* 상품명 + 수량 */}
+                      <div className="flex-1">
+                        <p className="font-medium">{item.productName}</p>
+                        <p className="text-sm text-gray-500">{item.quantity}개</p>
+                      </div>
+
+                      {/* 가격 */}
+                      <div className="font-semibold">
+                        {item.orderPrice.toLocaleString()}원
+                      </div>
                     </li>
                   ))}
                 </ul>
+
 
                 {/* 버튼 영역 */}
                 <div className="flex gap-2 mt-4">

--- a/frontend/src/app/payment/page.tsx
+++ b/frontend/src/app/payment/page.tsx
@@ -1,10 +1,210 @@
-"use client";
+"use client"
 
-export default function Home() {
+import { useEffect, useState } from "react"
+import { useRouter } from "next/navigation"
+import { fetchApi } from "@/lib/client"
+
+type Address = {
+  addressId: number
+  userId: number
+  address: string
+  addressDetail: string
+  postNumber: string
+}
+
+type User = {
+  userId: number
+  userEmail: string
+  phoneNumber: string
+}
+
+type CartItem = {
+  cartId: number
+  menuId: number
+  name: string
+  imageUrl: string
+  price: number
+  quantity: number
+  orderAmount: number
+}
+
+type CartResponse = {
+  cartItems: CartItem[]
+  grandTotal: number
+}
+
+export default function CheckoutPage() {
+  const router = useRouter()
+
+  const [addresses, setAddresses] = useState<Address[]>([])
+  const [selectedId, setSelectedId] = useState<number | null>(null)
+  const [user, setUser] = useState<User | null>(null)
+
+  const [cart, setCart] = useState<CartResponse | null>(null)
+
+  // 초기 데이터 불러오기
+  useEffect(() => {
+    async function loadData() {
+      try {
+        // 주소 목록
+        const addrRes = await fetchApi("/api/users/address/list", { method: "GET" })
+        setAddresses(addrRes.data)
+        if (addrRes.data.length > 0) setSelectedId(addrRes.data[0].addressId)
+
+        // 유저 정보
+        const userRes = await fetchApi("/api/users/my", { method: "GET" })
+        setUser(userRes.data)
+
+        // 장바구니
+        const cartRes = await fetchApi("/api/carts", { method: "GET" })
+        setCart(cartRes.data)
+      } catch (err) {
+        console.error("데이터 불러오기 실패:", err)
+      }
+    }
+    loadData()
+  }, [])
+
+  // 주소 변경
+  const handleAddressChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setSelectedId(Number(e.target.value))
+  }
+
+  // 주문 생성
+  const handleOrder = async () => {
+    if (selectedId === null) {
+      alert("배송지를 선택해주세요.")
+      return
+    }
+    if (!cart || cart.cartItems.length === 0) {
+      alert("장바구니가 비어있습니다.")
+      return
+    }
+
+    try {
+      // cartItems → items 변환
+      const items = cart.cartItems.map((c) => ({
+        productId: c.menuId,       // ✅ DTO에서 요구하는 필드
+        menuName: c.name,          // ✅ 메뉴명
+        quantity: c.quantity,      // ✅ 수량
+        orderPrice: c.orderAmount, // ✅ 합계 금액
+      }))
+
+      // 1. 주문 생성
+      const orderRes = await fetchApi("/api/orders", {
+        method: "POST",
+        body: JSON.stringify({
+          amount: cart.grandTotal, // ✅ 총 결제 금액
+          addressId: selectedId,   // ✅ 배송지 ID
+          items,                   // ✅ 주문 상세
+        }),
+      })
+
+      const orderId = orderRes.data.orderId
+
+      // 2. 결제 생성
+      await fetchApi("/api/payments/create", {
+        method: "POST",
+        body: JSON.stringify({
+          orderId,
+          paymentAmount: cart.grandTotal,
+          paymentMethod: "CARD",
+        }),
+      })
+
+      // 3. 주문 상세로 이동
+      router.push(`/orders`)
+    } catch (err) {
+      console.error("주문/결제 실패:", err)
+      alert("주문에 실패했습니다.")
+    }
+  }
+
+
+
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-bold">커피 CRUD payment 페이지입니다</h1>
-      {/* 여기에 앞으로 결제 관련 UI를 만들어 나가시면 됩니다. */}
+    <div className="min-h-screen bg-gray-50">
+      <main className="max-w-5xl mx-auto py-10 px-6 flex gap-8">
+        {/* 배송 정보 */}
+        <div className="flex-1 bg-white border rounded-lg p-6 space-y-6">
+          <h2 className="text-xl font-bold mb-4">배송 정보</h2>
+
+          {/* 주소 선택 */}
+          {addresses.length > 0 && (
+            <div className="mb-4">
+              <label className="block text-sm mb-1">배송지 선택</label>
+              <select
+                value={selectedId ?? ""}
+                onChange={handleAddressChange}
+                className="w-full border rounded px-3 py-2"
+              >
+                {addresses.map((addr) => (
+                  <option key={addr.addressId} value={addr.addressId}>
+                    [{addr.postNumber}] {addr.address} {addr.addressDetail}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm mb-1">받는 분 이메일 *</label>
+              <input
+                type="text"
+                value={user?.userEmail ?? ""}
+                className="w-full border rounded px-3 py-2"
+                readOnly
+              />
+            </div>
+            <div>
+              <label className="block text-sm mb-1">연락처 *</label>
+              <input
+                type="text"
+                value={user?.phoneNumber ?? ""}
+                className="w-full border rounded px-3 py-2"
+                readOnly
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* 결제 요약 */}
+        <div className="w-80 space-y-6">
+          <div className="bg-white border rounded-lg p-6 space-y-3">
+            <h2 className="text-lg font-bold">결제 정보</h2>
+
+            {/* 장바구니 아이템 */}
+            {cart?.cartItems.map((item) => (
+              <div key={item.cartId} className="flex gap-3 items-center border-b pb-2">
+                <img
+                  src={item.imageUrl}
+                  alt={item.name}
+                  className="w-12 h-12 object-cover rounded"
+                />
+                <div className="flex-1">
+                  <p className="text-sm font-medium">{item.name}</p>
+                  <p className="text-xs text-gray-500">수량: {item.quantity}개</p>
+                </div>
+                <span className="text-sm font-semibold">{item.orderAmount}원</span>
+              </div>
+            ))}
+
+            {/* 합계 */}
+            <div className="border-t pt-3 flex justify-between font-bold">
+              <span>총 결제 금액</span>
+              <span>{cart?.grandTotal}원</span>
+            </div>
+
+            <button
+              onClick={handleOrder}
+              className="w-full py-3 mt-4 rounded bg-black text-white font-semibold hover:bg-gray-800"
+            >
+              {cart?.grandTotal}원 결제하기
+            </button>
+          </div>
+        </div>
+      </main>
     </div>
-  );
+  )
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈 <!-- 이슈 번호를 적어주세요 -->
#143

## CheckoutPage 로직 정리
### 1. 초기 데이터 로딩
useEffect에서 3가지 API 호출:

GET /api/users/address/list → 사용자의 배송지 목록 불러오기

첫 번째 주소를 기본값으로 selectedId에 세팅.

GET /api/users/my → 현재 로그인된 유저 정보(email, phoneNumber).

GET /api/carts → 장바구니 아이템 목록 + 총 금액(grandTotal).

👉 이 데이터들이 각각 state에 들어감: addresses, user, cart.

### 2. UI 구성
배송 정보 영역
드롭다운으로 배송지 선택 가능 (selectedId).

선택된 유저 이메일, 연락처 표시 (수정 불가).

결제 요약 영역
장바구니 아이템 리스트 (cart.cartItems) 출력.

상품 이미지, 이름, 수량, 합계(orderAmount).

최종 합계 금액(grandTotal) 표시.

“결제하기” 버튼 노출.

### 3. 주문 생성 & 결제 처리 (handleOrder)
버튼 클릭 시 실행되는 흐름:

## 유효성 검사
selectedId === null → “배송지를 선택해주세요.”

장바구니가 비었으면 → “장바구니가 비어있습니다.”

### 주문 생성 (POST /api/orders)

## 순서
서버에서 주문 생성 → orderId 반환.

결제 생성 (POST /api/payments/create)

서버에서 mock 결제 처리 → 주문 상태가 PAID로 변경됨.

주문 내역 페이지로 이동

router.push("/orders") 호출.

이후 주문 목록 화면에서 확인 가능.

### 4. 흐름 요약
장바구니 → 주문 생성 → 결제 처리 → 주문 내역 이동

프론트는 주문/결제 요청만 하고,
주문 상태 변경(CREATED → PAID)은 백엔드가 결제 API에서 처리.