### PR TITLE
chore: 테스트를 위한 기본 메뉴 추가

### DIFF
--- a/backend/src/main/java/com/backend/global/init/BaseInitData.java
+++ b/backend/src/main/java/com/backend/global/init/BaseInitData.java
@@ -1,5 +1,7 @@
 package com.backend.global.init;
 
+import com.backend.domain.menu.entity.Menu;
+import com.backend.domain.menu.repository.MenuRepository;
 import com.backend.domain.user.user.entity.Users;
 import com.backend.domain.user.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +14,7 @@ import org.springframework.context.annotation.Configuration;
 public class BaseInitData {
 
     private final UserRepository userRepository;
+    private final MenuRepository menuRepository;
 
     @Bean
     CommandLineRunner initData() {
@@ -39,6 +42,49 @@ public class BaseInitData {
                 );
                 userRepository.save(user);
                 System.out.println("기본 사용자 계정 생성 완료");
+            }
+
+            //기본 메뉴 생성
+            if (menuRepository.count() == 0) {
+                menuRepository.save(new Menu(
+                        "에티오피아 예가체프 G1",
+                        25000,
+                        false,
+                        "산미와 화사한 꽃 향기가 특징인 스페셜티 원두",
+                        "https://i.postimg.cc/GHpyNHcW/ethiopia.jpg"
+                ));
+
+                menuRepository.save(new Menu(
+                        "콜롬비아 수프리모",
+                        20000,
+                        false,
+                        "부드러운 바디감과 고소한 견과류 향의 대표적인 원두",
+                        "https://i.postimg.cc/JGY04s7v/colombia.jpg"
+                ));
+
+                menuRepository.save(new Menu(
+                        "케냐 AA",
+                        28000,
+                        false,
+                        "묵직한 바디감과 와인 같은 풍미가 일품인 고급 원두",
+                        "https://i.postimg.cc/w3R0fjQF/kenya.jpg"
+                ));
+
+                menuRepository.save(new Menu(
+                        "브라질 산토스",
+                        18000,
+                        false,
+                        "균형 잡힌 맛과 부드러운 산미의 대중적인 원두",
+                        "https://i.postimg.cc/SJxjh64c/brazil.jpg"
+                ));
+
+                menuRepository.save(new Menu(
+                        "품절 메뉴",
+                        25000,
+                        true,
+                        "산미와 화사한 꽃 향기가 특징인 스페셜티 원두",
+                        "https://i.postimg.cc/GHpyNHcW/ethiopia.jpg"
+                ));
             }
         };
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈 <!-- 이슈 번호를 적어주세요 -->
#157 

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
테스트 환경에서 사용할 수 있도록 기본 메뉴 데이터를 초기화하는 기능을 추가했습니다.  
애플리케이션 실행 시 BaseInitData를 통해 기본 계정(관리자/사용자)과 함께 메뉴 데이터 5개가 자동 삽입되도록 구현했습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
1. `BaseInitData`에 기본 메뉴 생성 로직 추가  
2. DB에 메뉴 데이터가 없는 경우 초기 데이터 삽입 처리  
4. 예지님이 제공해주신 메뉴 데이터를 토대로 에티오피아 예가체프 G1, 콜롬비아 수프리모, 케냐 AA, 브라질 산토스, 품절 메뉴 총 5개 등록  
5. 각 메뉴에 이름, 가격, 설명, 이미지 URL 포함

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->