### PR TITLE
feature: 메뉴 조회 개선(품절 포함), 장바구니 이동 UI추가

### DIFF
--- a/backend/src/main/java/com/backend/domain/menu/service/MenuService.java
+++ b/backend/src/main/java/com/backend/domain/menu/service/MenuService.java
@@ -24,7 +24,7 @@ public class MenuService {
 
     // 전체 메뉴 조회(사용자)
     public ApiResponse<List<MenuResponse>> getAllMenu() {
-        List<MenuResponse> menus = menuRepository.findByIsSoldOutFalse().stream()
+        List<MenuResponse> menus = menuRepository.findAll().stream()
                 .map(MenuResponse::from)
                 .toList();
 

--- a/frontend/src/app/menu/page.tsx
+++ b/frontend/src/app/menu/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import { fetchApi } from "@/lib/client";
 
 interface Menu {
@@ -14,8 +15,9 @@ interface Menu {
 
 export default function Home() {
   const [menus, setMenus] = useState<Menu[]>([]);
+  const [showToast, setShowToast] = useState(false);
+  const router = useRouter();
 
-  // 메뉴 조회
   useEffect(() => {
     fetchApi("/api/menus")
       .then((data) => {
@@ -24,22 +26,21 @@ export default function Home() {
       .catch((err) => console.error("메뉴 불러오기 실패:", err));
   }, []);
 
-  // 장바구니 담기
-const handleAddToCart = async (menuId: number) => {
-  try {
-    await fetchApi("/api/carts/items", {
-      method: "POST",
-      body: JSON.stringify({
-        menuId: menuId,
-        quantity: 1
-      }),
-    });
-    alert("장바구니에 담겼습니다!");
-  } catch (err) {
-    console.error("장바구니 추가 실패:", err);
-    alert("장바구니 담기 실패 😢");
-  }
-};
+  const handleAddToCart = async (menuId: number) => {
+    try {
+      await fetchApi("/api/carts/items", {
+        method: "POST",
+        body: JSON.stringify({ menuId, quantity: 1 }),
+      });
+
+      // 토스트 보이기
+      setShowToast(true);
+      setTimeout(() => setShowToast(false), 3000);
+    } catch (err) {
+      console.error("장바구니 추가 실패:", err);
+      alert("장바구니 담기 실패 😢");
+    }
+  };
 
   return (
     <div className="min-h-screen flex flex-col items-center justify-center p-6 bg-white">
@@ -72,7 +73,9 @@ const handleAddToCart = async (menuId: number) => {
             {/* 내용 */}
             <div className="p-4 flex flex-col gap-2 flex-grow">
               <h3 className="text-black font-semibold">{menu.name}</h3>
-              <p className="text-sm text-gray-400 truncate" title={menu.description} >{menu.description}</p>
+              <p className="text-sm text-gray-400 truncate" title={menu.description}>
+                {menu.description}
+              </p>
               <p className="text-black font-bold mt-auto">
                 {menu.price.toLocaleString()}원
               </p>
@@ -93,6 +96,21 @@ const handleAddToCart = async (menuId: number) => {
           </div>
         ))}
       </div>
+
+      {/* 토스트 (하단 고정) */}
+      {showToast && (
+        <div className="fixed bottom-4 inset-x-0 flex justify-center">
+          <div className="bg-black text-white px-4 py-3 rounded-lg shadow-lg flex items-center gap-4">
+            <span>장바구니에 담겼습니다 🛒</span>
+            <button
+              onClick={() => router.push("/cart")}
+              className="bg-white text-black px-3 py-1 rounded text-sm"
+            >
+              장바구니로 이동
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/header.tsx
+++ b/frontend/src/components/header.tsx
@@ -30,6 +30,10 @@ export function Header() {
       <nav className="hidden md:flex items-center gap-4 text-sm font-medium">
         <Link href="/menu" className="hover:text-primary">홈</Link>
         <Link href="/orders" className="hover:text-primary">주문내역</Link>
+        {/* 관리자 전용 메뉴 */}
+        {user?.level === 0 && (
+          <Link href="/admin" className="hover:text-primary">관리자 대시보드</Link>
+        )}
       </nav>
       <div className="flex items-center gap-4">
         {isLoading ? (

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -8,6 +8,7 @@ import { createContext, useContext, useState, useEffect, ReactNode } from "react
 type User = {
   userId: number;
   email: string; // username 대신 email 사용
+  level: number;
 };
 
 type AuthContextType = {


### PR DESCRIPTION
## #️⃣ 연관된 이슈 <!-- 이슈 번호를 적어주세요 -->
#162 

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->

사용자 메뉴 조회 화면에서 품절 상태의 메뉴도 회색 처리 및 "품절" 배지와 함께 표시되도록 개선했습니다.
또한 메뉴를 장바구니에 담을 경우, 하단에 장바구니 이동 UI가 나타나도록 수정하여 사용자 경험을 향상시켰습니다.
헤더에 관리자 로그인 시 관리자 대시보드 메뉴 추가하였습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

- 메뉴 조회 시 품절 메뉴도 함께 표시되도록 수정
- 품절 메뉴의 이미지에 회색 처리 적용 및 "품절" 배지 노출
- 품절 메뉴의 장바구니 버튼 비활성화 처리
- 장바구니 담기 성공 시 화면 하단에 알림 UI(토스트) 표시
- 알림 UI에서 "장바구니로 이동" 버튼 제공 → 클릭 시 /cart 페이지로 이동
- 관리자 로그인시 level 확인하여 관리자 대시보드 표시

[품절 메뉴가 포함된 메뉴 조회]
<img width="1655" height="1164" alt="스크린샷 2025-09-28 194322" src="https://github.com/user-attachments/assets/90c9df8f-f438-4288-8be1-0659d7ca09d4" />

[장바구니 담기 버튼 클릭 시 하단에 장바구니 UI 표시]
<img width="1670" height="1180" alt="스크린샷 2025-09-28 194351" src="https://github.com/user-attachments/assets/6fd3a2df-9ce5-4024-abb3-1ef349693982" />

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

