### PR TITLE
feature: 결제 성공/실패 페이지, main 리다이렉트

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,15 +1,16 @@
 import type { NextConfig } from "next";
 
-/** @type {import('next').NextConfig} */
-const nextConfig = {
-  // 이 부분을 추가해주세요!
+const nextConfig: NextConfig = {
   images: {
     remotePatterns: [
       {
-        protocol: 'https',
-        hostname: '**.public.blob.vercel-storage.com',
+        protocol: "https",
+        hostname: "i.postimg.cc", // ✅ postimg 도메인 허용
       },
-      // 만약 다른 도메인을 사용한다면 여기에 추가하면 됩니다.
+      {
+        protocol: "https",
+        hostname: "**.public.blob.vercel-storage.com", // 기존 설정 유지
+      },
     ],
   },
 };

--- a/frontend/src/app/orders/page.tsx
+++ b/frontend/src/app/orders/page.tsx
@@ -29,7 +29,7 @@ export default function OrdersPage() {
     async function loadOrders() {
       try {
         const res = await fetchApi("/api/orders", { method: "GET" })
-        setOrders(res.data)
+        setOrders(res.data) // ApiResponse 구조라면 .data
       } catch (err) {
         console.error("주문 조회 실패:", err)
       } finally {
@@ -42,10 +42,11 @@ export default function OrdersPage() {
   if (loading) return <div className="p-6">불러오는 중...</div>
 
   const sortedOrders = [...orders].sort(
-    (a, b) => new Date(b.orderTime).getTime() - new Date(a.orderTime).getTime()
+    (a, b) =>
+      new Date(b.orderTime).getTime() - new Date(a.orderTime).getTime()
   )
 
-// ✅ 주문 취소 → status 변경 + 버튼 변경
+  // ✅ 주문 취소 → status 변경 + 버튼 변경
   const handleCancel = async (orderId: number) => {
     try {
       await fetchApi(`/api/orders/${orderId}/cancel`, {
@@ -82,21 +83,17 @@ export default function OrdersPage() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <header className="border-b bg-white p-4">
-        <h1 className="text-xl font-bold">카페 원두</h1>
-      </header>
+      {/* 헤더는 나중에 <Header /> 로 대체 */}
+      <header />
 
       <main className="max-w-3xl mx-auto py-10 px-4">
         <div className="flex items-center gap-2 mb-6">
-          <Link href="/" className="text-sm text-gray-600">
-            ← 홈으로 돌아가기
-          </Link>
-          <h1 className="text-2xl font-bold ml-4">주문내역</h1>
+          <h1 className="text-2xl font-bold ml-4">주문 내역</h1>
         </div>
 
         {sortedOrders.length === 0 ? (
           <div className="text-center py-16">
-            <h2 className="text-2xl font-bold mb-2">주문내역이 없습니다</h2>
+            <h2 className="text-2xl font-bold mb-2">주문 내역이 없습니다</h2>
             <p className="text-gray-500 mb-6">첫 주문을 시작해보세요</p>
             <Link href="/">
               <button className="px-4 py-2 border rounded bg-black text-white">
@@ -116,11 +113,10 @@ export default function OrdersPage() {
                     주문번호 #{order.orderId}
                   </h2>
                   <span
-                    className={`text-sm border px-2 py-0.5 rounded ${
-                      order.status === "CANCELED"
-                        ? "text-red-600 border-red-600"
-                        : "text-green-600 border-green-600"
-                    }`}
+                    className={`text-sm border px-2 py-0.5 rounded ${order.status === "CANCELED"
+                      ? "text-red-600 border-red-600"
+                      : "text-green-600 border-green-600"
+                      }`}
                   >
                     {order.status}
                   </span>
@@ -140,25 +136,28 @@ export default function OrdersPage() {
                   {order.items.map((item, idx) => (
                     <li
                       key={`${order.orderId}-${idx}`}
-                      className="flex items-center gap-4 py-2 border-b"
-                    >
+                      className="flex items-center gap-4 py-2 border-b">
+                      {/* 상품 이미지 */}
                       <img
                         src={item.imageUrl}
                         alt={item.productName}
                         className="w-16 h-16 object-cover rounded"
                       />
+
+                      {/* 상품명 + 수량 */}
                       <div className="flex-1">
                         <p className="font-medium">{item.productName}</p>
-                        <p className="text-sm text-gray-500">
-                          {item.quantity}개
-                        </p>
+                        <p className="text-sm text-gray-500">{item.quantity}개</p>
                       </div>
+
+                      {/* 가격 */}
                       <div className="font-semibold">
                         {item.orderPrice.toLocaleString()}원
                       </div>
                     </li>
                   ))}
                 </ul>
+
 
                 {/* 버튼 영역 */}
                 <div className="flex gap-2 mt-4">
@@ -171,14 +170,19 @@ export default function OrdersPage() {
                   {order.status === "CANCELED" ? (
                     <button
                       className="flex-1 w-full border rounded py-2 text-sm bg-gray-50 hover:bg-gray-100 text-gray-600 text-center"
-                      onClick={() => handleDelete(order.orderId, order.paymentId)}
+                      onClick={() => handleDelete(order.orderId)}
                     >
                       삭제
                     </button>
                   ) : (
                     <button
-                      className="flex-1 w-full border rounded py-2 text-sm bg-red-50 hover:bg-red-100 text-red-600 text-center"
-                      onClick={() => handleCancel(order.orderId, order.paymentId)}
+                      disabled={order.status === "COMPLETED"}
+                      className={`flex-1 w-full border rounded py-2 text-sm text-center
+      ${order.status === "COMPLETED"
+                          ? "bg-gray-200 text-gray-400 cursor-not-allowed"
+                          : "bg-red-50 hover:bg-red-100 text-red-600"
+                        }`}
+                      onClick={() => handleCancel(order.orderId)}
                     >
                       취소
                     </button>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { redirect } from "next/navigation";
+
 export default function Home() {
-  return <div>커피 CRUD 메인 페이지</div>;
+  redirect("/menu");
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,7 +1,48 @@
 "use client";
 
-import { redirect } from "next/navigation";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { fetchApi, ApiResponse } from "@/lib/client";
+
+type User = {
+  userId: number;
+  userEmail: string;
+  phoneNumber: string;
+  createDate: string;
+  modifyDate: string;
+  level: number; // 0 = 관리자, 1 = 일반 사용자
+  apiKey: string;
+};
 
 export default function Home() {
-  redirect("/menu");
+  const router = useRouter();
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchUser = async () => {
+      try {
+        const res = await fetchApi<User>("/api/users/my", { method: "GET" });
+        const user = res.data;
+
+        if (user.level === 0) {
+          router.replace("/admin");
+        } else if (user.level === 1) {
+          router.replace("/menu");
+        } else {
+          router.replace("/user");
+        }
+      } catch (error) {
+        console.error("사용자 정보 불러오기 실패:", error);
+        router.replace("/user");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchUser();
+  }, [router]);
+
+  if (loading) return <div>로딩 중...</div>;
+
+  return null;
 }

--- a/frontend/src/app/payment/fail/page.tsx
+++ b/frontend/src/app/payment/fail/page.tsx
@@ -1,0 +1,52 @@
+// src/app/payment/fail/page.tsx
+"use client"
+
+import { useRouter } from "next/navigation"
+
+export default function PaymentFailPage() {
+  const router = useRouter()
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <main className="max-w-2xl mx-auto py-10 px-6">
+        <div className="text-center">
+          {/* 실패 아이콘 */}
+          <div className="w-16 h-16 mx-auto mb-4 flex items-center justify-center">
+            <svg className="w-16 h-16 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z" />
+            </svg>
+          </div>
+          
+          <h1 className="text-3xl font-bold mb-2">결제에 실패했습니다</h1>
+          <p className="text-gray-600 mb-8">
+            결제 처리 중 문제가 발생했습니다. 다시 시도해 주세요.
+          </p>
+
+          {/* 실패 안내 정보 */}
+          <div className="bg-red-50 border border-red-200 rounded-lg p-6 mb-8">
+            <h3 className="font-semibold mb-2 text-red-800">결제 실패 안내</h3>
+            <ul className="text-sm text-red-700 space-y-1 text-left">
+              <li>• 카드 정보를 다시 확인해 주세요</li>
+              <li>• 결제 한도를 확인해 주세요</li>
+              <li>• 네트워크 연결 상태를 확인해 주세요</li>
+              <li>• 문제가 지속되면 고객센터로 문의해 주세요</li>
+            </ul>
+          </div>
+
+          {/* 버튼 그룹 */}
+          <div className="flex gap-4 justify-center">
+            <button 
+              onClick={() => router.push('/menu')}
+              className="px-6 py-3 bg-black text-white rounded hover:bg-gray-800 flex items-center gap-2"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+              </svg>
+              메뉴로 가기
+            </button>
+          </div>
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/frontend/src/app/payment/page.tsx
+++ b/frontend/src/app/payment/page.tsx
@@ -1,3 +1,4 @@
+// src/app/payment/page.tsx
 "use client"
 
 import { useEffect, useState } from "react"
@@ -112,11 +113,11 @@ export default function CheckoutPage() {
         }),
       })
 
-      // 3. 주문 상세로 이동
-      router.push(`/orders`)
+      // 3. 주문 성공 페이지로로 이동
+      router.push(`/payment/success?orderId=${orderId}`)
     } catch (err) {
       console.error("주문/결제 실패:", err)
-      alert("주문에 실패했습니다.")
+      router.push(`/payment/fail`)
     }
   }
 

--- a/frontend/src/app/payment/success/page.tsx
+++ b/frontend/src/app/payment/success/page.tsx
@@ -1,0 +1,246 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useRouter, useSearchParams } from "next/navigation"
+import { fetchApi } from "@/lib/client"
+import Link from "next/link"
+
+// 백엔드 API 응답 타입 정의
+interface OrderSummaryDetailResponse {
+  productName: string
+  quantity: number
+  orderPrice: number
+  imageUrl?: string
+}
+
+interface OrderSummaryResponse {
+  orderId: number
+  orderTime: string
+  orderAmount: number
+  status: string
+  address: string
+  paymentId: number
+  items: OrderSummaryDetailResponse[]
+}
+
+interface ApiResponse<T> {
+  code: string
+  message: string
+  data: T
+}
+
+export default function OrderSuccessPage() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const orderId = searchParams.get('orderId')
+  
+  const [order, setOrder] = useState<OrderSummaryResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    async function updateAndLoadOrder() {
+      try {
+        setLoading(true)
+        setError(null)
+
+        const res = await fetchApi(`/api/orders/${orderId}`, { method: "GET" })
+        setOrder(res.data)
+      } catch (err) {
+        console.error("주문 처리 실패:", err)
+        setError(err instanceof Error ? err.message : '주문 정보를 가져오는데 실패했습니다.')
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    if (orderId) {
+      updateAndLoadOrder()
+    } else {
+      setError("주문 번호가 없습니다.")
+      setLoading(false)
+    }
+  }, [orderId])
+
+  // 날짜 포맷팅 함수
+  const formatDate = (dateString: string) => {
+    return new Date(dateString).toLocaleString("ko-KR", {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit'
+    })
+  }
+
+  // 주문 상태 한글 변환
+  const getOrderStatusText = (status: string) => {
+    switch (status) {
+      case 'CREATED': return '주문완료'
+      case 'PAID': return '결제완료'
+      case 'COMPLETED': return '배송완료'
+      case 'CANCELED': return '주문취소'
+      default: return status
+    }
+  }
+
+  // 로딩 상태
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-gray-50">
+        <main className="max-w-2xl mx-auto py-10 px-6">
+          <div className="text-center">
+            <div className="animate-pulse">
+              <div className="h-16 w-16 bg-gray-200 rounded-full mx-auto mb-4"></div>
+              <div className="h-8 bg-gray-200 rounded mb-2 w-1/2 mx-auto"></div>
+              <div className="h-4 bg-gray-200 rounded w-3/4 mx-auto"></div>
+            </div>
+          </div>
+        </main>
+      </div>
+    )
+  }
+
+  // 에러 상태
+  if (error || !order) {
+    return (
+      <div className="min-h-screen bg-gray-50">
+        <main className="max-w-2xl mx-auto py-10 px-6">
+          <div className="text-center">
+            <div className="w-16 h-16 mx-auto mb-4 flex items-center justify-center">
+              <svg className="w-16 h-16 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z" />
+              </svg>
+            </div>
+            <h1 className="text-3xl font-bold mb-2">오류가 발생했습니다</h1>
+            <p className="text-gray-600 mb-8">
+              {error || "주문 정보를 찾을 수 없습니다."}
+            </p>
+            <div className="flex gap-4 justify-center">
+              <Link href="/orders">
+                <button className="px-6 py-2 border border-gray-300 rounded text-gray-700 hover:bg-gray-50">
+                  주문내역 보기
+                </button>
+              </Link>
+              <Link href="/">
+                <button className="px-6 py-2 bg-black text-white rounded hover:bg-gray-800">
+                  홈으로 가기
+                </button>
+              </Link>
+            </div>
+          </div>
+        </main>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <main className="max-w-2xl mx-auto py-10 px-6">
+        <div className="text-center">
+          {/* 성공 아이콘 */}
+          <div className="w-16 h-16 mx-auto mb-4 flex items-center justify-center">
+            <svg className="w-16 h-16 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+          </div>
+          
+          <h1 className="text-3xl font-bold mb-2">주문이 완료되었습니다!</h1>
+          <p className="text-gray-600 mb-8">
+            주문해 주셔서 감사합니다. 신선한 원두를 정성껏 준비하여 배송해드리겠습니다.
+          </p>
+
+          {/* 주문 정보 카드 */}
+          <div className="bg-white border rounded-lg mb-8">
+            <div className="border-b px-6 py-4">
+              <div className="flex items-center gap-2 justify-center">
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" />
+                </svg>
+                <h2 className="text-lg font-bold">주문 정보</h2>
+              </div>
+            </div>
+            
+            <div className="p-6 space-y-4">
+              <div className="grid grid-cols-2 gap-4 text-sm">
+                <div>
+                  <span className="text-gray-500">주문번호</span>
+                  <div className="font-medium">#{order.orderId}</div>
+                </div>
+                <div>
+                  <span className="text-gray-500">주문일시</span>
+                  <div className="font-medium">{formatDate(order.orderTime)}</div>
+                </div>
+                <div>
+                  <span className="text-gray-500">결제금액</span>
+                  <div className="font-medium text-blue-600">{order.orderAmount.toLocaleString()}원</div>
+                </div>
+                <div>
+                  <span className="text-gray-500">주문상태</span>
+                  <div className="font-medium text-green-600">{getOrderStatusText(order.status)}</div>
+                </div>
+              </div>
+
+              {order.address && (
+                <div className="text-left">
+                  <span className="text-gray-500 text-sm">배송주소</span>
+                  <div className="font-medium">{order.address}</div>
+                </div>
+              )}
+
+              <div className="text-left">
+                <span className="text-gray-500 text-sm">주문상품</span>
+                <div className="space-y-2 mt-2">
+                  {order.items.map((item, index) => (
+                    <div key={index} className="flex justify-between text-sm">
+                      <span>
+                        {item.productName} x {item.quantity}
+                      </span>
+                      <span className="font-medium">{item.orderPrice.toLocaleString()}원</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {order.paymentId && (
+                <div className="text-left">
+                  <span className="text-gray-500 text-sm">결제번호</span>
+                  <div className="font-medium">#{order.paymentId}</div>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* 배송 안내 */}
+          <div className="bg-gray-100 rounded-lg p-6 mb-8">
+            <h3 className="font-semibold mb-2">배송 안내</h3>
+            <ul className="text-sm text-gray-600 space-y-1 text-left">
+              <li>• 금일 오후 2시부터 익일 오후 2시까지 결제된 건에 대해서는 익일 오후 2시에 일괄 배송 처리됩니다</li>
+              <li>• 배송 조회는 주문내역에서 확인 가능합니다</li>
+            </ul>
+          </div>
+
+          {/* 버튼 그룹 */}
+          <div className="flex gap-4 justify-center">
+            <Link href="/orders">
+              <button className="px-6 py-3 border border-gray-300 rounded text-gray-700 hover:bg-gray-50 flex items-center gap-2">
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                </svg>
+                주문내역 보기
+              </button>
+            </Link>
+            <Link href="/">
+              <button className="px-6 py-3 bg-black text-white rounded hover:bg-gray-800 flex items-center gap-2">
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+                </svg>
+                홈으로 가기
+              </button>
+            </Link>
+          </div>
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/frontend/src/lib/client.ts
+++ b/frontend/src/lib/client.ts
@@ -1,23 +1,27 @@
-export function fetchApi(url: string, options?: RequestInit) {
+// lib/client.ts
+export type ApiResponse<T> = {
+  code: string;
+  message: string;
+  data: T;
+};
+
+export async function fetchApi<T>(url: string, options?: RequestInit): Promise<ApiResponse<T>> {
   if (options?.body) {
     const headers = new Headers(options.headers || {});
     headers.set("Content-Type", "application/json");
     options.headers = headers;
   }
 
-  return fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}${url}`, {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}${url}`, {
     ...options,
-    credentials: "include", // 세션 쿠키도 전송
-  }).then(async (res) => {
-    if (!res.ok) { // 200~299가 아닌 경우
-      let rsData: any = {};
-      try {
-        rsData = await res.json();
-      } catch {
-        // JSON이 아니어도 에러는 던지게
-      }
-      throw new Error(rsData.msg || "API 요청 실패");
-    }
-    return res.json();
+    credentials: "include", // 세션 쿠키 전송
   });
+
+  const rsData = await res.json();
+
+  if (!res.ok || rsData.code !== "200") {
+    throw new Error(rsData.message || "API 요청 실패");
+  }
+
+  return rsData;
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈 <!-- 이슈 번호를 적어주세요 -->
작성해서 추가해 두겠습니다!

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
1. 결제 진행 시 성공/실패 페이지 추가했습니다.
2. 루트 page.tsx 수정


## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
9dad79c: 루트 page.tsx 수정
- 로그인이 되어 있지 않을 경우 자동으로 로그인 화면으로 리다이렉트
- 어드민 계정으로 로그인할 경우 관리자 대시보드로 리다이렉트
- 사용자 계정으로 로그인할 경우 메뉴 화면으로 리다이렉트

0599b02: 결제 성공, 실패 페이지 추가
<img width="1919" height="910" alt="image" src="https://github.com/user-attachments/assets/e6b2efc1-c276-4a41-b376-4b5a410559b6" />
<img width="1898" height="675" alt="image" src="https://github.com/user-attachments/assets/26bf494c-e440-422e-93c3-5b15f801629e" />

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
현재 장바구니에서 결제 화면으로 넘어갈 때 배송비가 합산되지 않은 가격으로 넘어가는 것을 확인했습니다.
만약 배송비까지 추가하고자 한다면 서버에서 배송비 계산을 하는 방향으로 가야 할 것 같아요.
코드가 비교적 간단할 것 같기는 하나, 배송비 포함/미포함에 대한 의견 남겨 주시면 감사하겠습니다!