### PR TITLE
fix:결제 페이지 배송비 뜨게 수정 + 결제 내역 관련 수정

### DIFF
--- a/frontend/src/app/orders/admin/page.tsx
+++ b/frontend/src/app/orders/admin/page.tsx
@@ -30,7 +30,8 @@ export default function AdminOrdersPage() {
   async function loadOrders() {
     try {
       const res = await fetchApi("/api/admin/orders", { method: "GET" })
-      setOrders(res.data)
+      setOrders(res.data as AdminOrder[])
+      console.log("주문 목록:", res.data)
     } catch (err) {
       console.error("주문 목록 조회 실패:", err)
     } finally {

--- a/frontend/src/app/orders/page.tsx
+++ b/frontend/src/app/orders/page.tsx
@@ -125,7 +125,11 @@ export default function OrdersPage() {
                   <span
                     className={`text-sm border px-2 py-0.5 rounded ${order.status === "CANCELED"
                       ? "text-red-600 border-red-600"
-                      : "text-green-600 border-green-600"
+                      : order.status === "CREATED"
+                        ? "text-red-600 border-red-600"
+                        : order.status === "COMPLETED"
+                          ? "text-gray-600 border-gray-400"
+                          : "text-green-600 border-green-600"
                       }`}
                   >
                     {getStatusText(order.status)}
@@ -171,11 +175,20 @@ export default function OrdersPage() {
 
                 {/* 버튼 영역 */}
                 <div className="flex gap-2 mt-4">
-                  <Link href={`/payment/${order.paymentId}`} className="flex-1">
-                    <button className="w-full border rounded py-2 text-sm bg-blue-50 hover:bg-blue-100 text-center">
-                      결제확인
+                  {order.paymentId ? (
+                    <Link href={`/payment/${order.paymentId}`} className="flex-1">
+                      <button className="w-full border rounded py-2 text-sm bg-blue-50 hover:bg-blue-100 text-center">
+                        결제확인
+                      </button>
+                    </Link>
+                  ) : (
+                    <button
+                      disabled
+                      className="flex-1 w-full border rounded py-2 text-sm bg-gray-200 text-gray-400 cursor-not-allowed"
+                    >
+                      결제 내역 없음
                     </button>
-                  </Link>
+                  )}
 
                   {order.status === "CANCELED" ? (
                     <button

--- a/frontend/src/app/payment/page.tsx
+++ b/frontend/src/app/payment/page.tsx
@@ -1,4 +1,3 @@
-// src/app/payment/page.tsx
 "use client"
 
 import { useEffect, useState } from "react"
@@ -41,23 +40,19 @@ export default function CheckoutPage() {
   const [addresses, setAddresses] = useState<Address[]>([])
   const [selectedId, setSelectedId] = useState<number | null>(null)
   const [user, setUser] = useState<User | null>(null)
-
   const [cart, setCart] = useState<CartResponse | null>(null)
 
   // 초기 데이터 불러오기
   useEffect(() => {
     async function loadData() {
       try {
-        // 주소 목록
         const addrRes = await fetchApi("/api/users/address/list", { method: "GET" })
         setAddresses(addrRes.data)
         if (addrRes.data.length > 0) setSelectedId(addrRes.data[0].addressId)
 
-        // 유저 정보
         const userRes = await fetchApi("/api/users/my", { method: "GET" })
         setUser(userRes.data)
 
-        // 장바구니
         const cartRes = await fetchApi("/api/carts", { method: "GET" })
         setCart(cartRes.data)
       } catch (err) {
@@ -72,8 +67,6 @@ export default function CheckoutPage() {
     setSelectedId(Number(e.target.value))
   }
 
-
-
   // 주문 생성
   const handleOrder = async () => {
     if (selectedId === null) {
@@ -86,23 +79,20 @@ export default function CheckoutPage() {
     }
 
     try {
-      // 배송비 계산
       const shippingFee = cart.grandTotal < 50000 ? 3000 : 0
       const totalAmount = cart.grandTotal + shippingFee
 
-      // cartItems → items 변환
       const items = cart.cartItems.map((c) => ({
-        productId: c.menuId,       // ✅ DTO에서 요구하는 필드
-        menuName: c.name,          // ✅ 메뉴명
-        quantity: c.quantity,      // ✅ 수량
-        orderPrice: c.orderAmount, // ✅ 합계 금액
+        productId: c.menuId,
+        menuName: c.name,
+        quantity: c.quantity,
+        orderPrice: c.orderAmount,
       }))
 
-      // 1. 주문 생성
       const orderRes = await fetchApi("/api/orders", {
         method: "POST",
         body: JSON.stringify({
-          amount: totalAmount,   // ✅ 배송비 포함 금액
+          amount: totalAmount,
           addressId: selectedId,
           items,
         }),
@@ -110,17 +100,15 @@ export default function CheckoutPage() {
 
       const orderId = orderRes.data.orderId
 
-      // 2. 결제 생성
       await fetchApi("/api/payments/create", {
         method: "POST",
         body: JSON.stringify({
           orderId,
-          paymentAmount: totalAmount, // ✅ 배송비 포함 금액
+          paymentAmount: totalAmount,
           paymentMethod: "CARD",
         }),
       })
 
-      // 3. 주문 성공 페이지로로 이동
       router.push(`/payment/success?orderId=${orderId}`)
     } catch (err) {
       console.error("주문/결제 실패:", err)
@@ -128,7 +116,9 @@ export default function CheckoutPage() {
     }
   }
 
-
+  const shippingFee = cart && cart.grandTotal < 50000 ? 3000 : 0
+  const productTotal = cart?.grandTotal ?? 0
+  const totalAmount = productTotal + shippingFee
 
   return (
     <div className="min-h-screen bg-gray-50">
@@ -137,7 +127,6 @@ export default function CheckoutPage() {
         <div className="flex-1 bg-white border rounded-lg p-6 space-y-6">
           <h2 className="text-xl font-bold mb-4">배송 정보</h2>
 
-          {/* 주소 선택 */}
           {addresses.length > 0 ? (
             <div className="mb-4">
               <label className="block text-sm mb-1">배송지 선택</label>
@@ -155,19 +144,19 @@ export default function CheckoutPage() {
             </div>
           ) : (
             <div className="bg-red-50 border border-red-200 rounded-lg p-6 mb-8">
-            <h3 className="font-semibold mb-2 text-red-800">주소 등록 안내내</h3>
-            <ul className="text-sm text-red-700 space-y-1 text-left">
-              <li>• 마이페이지에서 주소를 등록해 주세요</li>
-              <Link href="/user/address/add">
-                <button className="px-6 py-3 bg-black text-white rounded hover:bg-gray-800 flex items-center gap-2">
-                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
-                  </svg>
-                  주소 등록하러 가기기
-                </button>
-              </Link>
-            </ul>
-          </div>
+              <h3 className="font-semibold mb-2 text-red-800">주소 등록 안내</h3>
+              <ul className="text-sm text-red-700 space-y-1 text-left">
+                <li>• 마이페이지에서 주소를 등록해 주세요</li>
+                <Link href="/user/address/add">
+                  <button className="px-6 py-3 bg-black text-white rounded hover:bg-gray-800 flex items-center gap-2">
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+                    </svg>
+                    주소 등록하러 가기
+                  </button>
+                </Link>
+              </ul>
+            </div>
           )}
 
           <div className="grid grid-cols-2 gap-4">
@@ -197,7 +186,6 @@ export default function CheckoutPage() {
           <div className="bg-white border rounded-lg p-6 space-y-3">
             <h2 className="text-lg font-bold">결제 정보</h2>
 
-            {/* 장바구니 아이템 */}
             {cart?.cartItems.map((item) => (
               <div key={item.cartId} className="flex gap-3 items-center border-b pb-2">
                 <img
@@ -213,17 +201,27 @@ export default function CheckoutPage() {
               </div>
             ))}
 
-            {/* 합계 */}
-            <div className="border-t pt-3 flex justify-between font-bold">
-              <span>총 결제 금액</span>
-              <span>{(cart?.grandTotal ?? 0) + (cart && cart.grandTotal < 50000 ? 3000 : 0)}원</span>
+            {/* 상품 금액, 배송비, 총 결제 금액 */}
+            <div className="space-y-1">
+              <div className="flex justify-between text-sm">
+                <span>상품 금액</span>
+                <span>{productTotal.toLocaleString()}원</span>
+              </div>
+              <div className="flex justify-between text-sm">
+                <span>배송비</span>
+                <span>{shippingFee === 0 ? "무료" : `${shippingFee.toLocaleString()}원`}</span>
+              </div>
+              <div className="border-t pt-3 flex justify-between font-bold">
+                <span>총 결제 금액</span>
+                <span>{totalAmount.toLocaleString()}원</span>
+              </div>
             </div>
 
             <button
               onClick={handleOrder}
               className="w-full py-3 mt-4 rounded bg-black text-white font-semibold hover:bg-gray-800"
             >
-              {(cart?.grandTotal ?? 0) + (cart && cart.grandTotal < 50000 ? 3000 : 0)}원 결제하기
+              {totalAmount.toLocaleString()}원 결제하기
             </button>
           </div>
         </div>


### PR DESCRIPTION
## #️⃣ 연관된 이슈 <!-- 이슈 번호를 적어주세요 -->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
50000원 아래이면 배송비가 3000원으로 보이고
50000원 이상이면 배송비가 무료로 보이도록 수정했습니다.
주문 내역에서 결제 실패한 건에 대해서 결제 조회 막고
주문 내역에서 결제 실패한 건은 결제 실패 빨간색으로 표시되게 수정했습니다