### PR TITLE
refactor: admin & menu 컴포넌트 분리 및 Menu 타입 통합

### DIFF
--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -1,47 +1,32 @@
+// src/app/admin/page.tsx
 "use client";
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { fetchApi } from "@/lib/client";
 import { useAuth } from "@/context/AuthContext";
+import { Menu } from "@/types/menu";
 
-interface Menu {
-  menuId?: number;
-  name: string;
-  price: number;
-  isSoldOut: boolean;
-  description: string;
-  imageUrl: string;
-}
+import CreateMenuForm from "@/components/admin/CreateMenuForm";
+import EditMenuForm from "@/components/admin/EditMenuForm";
+import AdminMenuCard from "@/components/admin/AdminMenuCard";
+import AdminGuard from "@/components/auth/AdminGuard";
 
-export default function AdminDashboard() {
-  const { user, isLoading } = useAuth();
+function AdminDashboardContent() {
+  const { user } = useAuth();
   const [menus, setMenus] = useState<Menu[]>([]);
-  const router = useRouter();
   const [showCreateForm, setShowCreateForm] = useState(false);
   const [editingMenu, setEditingMenu] = useState<Menu | null>(null);
 
-// 로딩 처리
-if (isLoading) {
-  return <div className="p-6 text-center">로딩 중...</div>;
-}
-
-// 관리자 권한 없는 경우
-if (!user || user.level !== 0) {
-  if (typeof window !== "undefined") {
-    router.push("/menu"); // 홈으로 리다이렉트
-  }
-  return null; // 화면에는 아무것도 안 그림
-}
-
-// 메뉴 불러오기
-useEffect(() => {
-  fetchApi("/api/admin/menus")
-    .then((data) => {
-      if (Array.isArray(data?.data)) setMenus(data.data);
-    })
-    .catch((err) => console.error("메뉴 불러오기 실패:", err));
-}, []);
+  // 메뉴 불러오기
+  useEffect(() => {
+    if (!user || user.level !== 0) return;
+    fetchApi("/api/admin/menus")
+      .then((data) => {
+        if (Array.isArray(data?.data)) setMenus(data.data);
+      })
+      .catch((err) => console.error("메뉴 불러오기 실패:", err));
+  }, [user]);
 
   // 메뉴 추가
   const handleCreate = async (menu: Menu) => {
@@ -158,272 +143,24 @@ useEffect(() => {
       {/* 메뉴 리스트 */}
       <div className="grid gap-6 mt-6">
         {menus.map((menu) => (
-          <div
+          <AdminMenuCard
             key={menu.menuId}
-            className="flex items-center border rounded-lg shadow-sm p-4"
-          >
-            <img
-              src={menu.imageUrl}
-              alt={menu.name}
-              className="w-24 h-24 object-cover rounded"
-            />
-            <div className="ml-4 flex-1">
-              <h3 className="text-lg font-semibold text-black">{menu.name}</h3>
-              <p className="text-sm text-gray-600 line-clamp-2">
-                {menu.description}
-              </p>
-              <p className="text-md font-bold mt-1 text-black">
-                {menu.price.toLocaleString()}원
-              </p>
-            </div>
-
-            <div className="flex gap-4 items-center">
-              {/* 품절 토글 - 개선된 버전 */}
-              <div className="flex items-center gap-2">
-                <span className="text-sm text-gray-600">
-                  {menu.isSoldOut ? "품절" : "재고있음"}
-                </span>
-                <button
-                  onClick={() => handleToggleSoldOut(menu.menuId!, menu.isSoldOut)}
-                  className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 ${menu.isSoldOut
-                      ? 'bg-gray-300 focus:ring-gray-500'
-                      : 'bg-green-500 focus:ring-green-500'
-                    }`}
-                >
-                  <span
-                    className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform duration-200 ${menu.isSoldOut ? 'translate-x-1' : 'translate-x-6'
-                      }`}
-                  />
-                </button>
-              </div>
-
-              {/* 수정 버튼 */}
-              <button
-                onClick={() => setEditingMenu(menu)}
-                className="px-3 py-1 border rounded text-black hover:bg-gray-50 transition-colors"
-              >
-                수정
-              </button>
-
-              {/* 삭제 버튼 */}
-              <button
-                onClick={() => handleDelete(menu.menuId!)}
-                className="px-3 py-1 border rounded text-red-500 hover:bg-red-50 transition-colors"
-              >
-                삭제
-              </button>
-            </div>
-          </div>
+            menu={menu}
+            onToggleSoldOut={handleToggleSoldOut}
+            onEdit={setEditingMenu}
+            onDelete={handleDelete}
+          />
         ))}
       </div>
     </div>
   );
 }
 
-//
-// 생성 폼 컴포넌트
-//
-function CreateMenuForm({
-  onCancel,
-  onSave,
-}: {
-  onCancel: () => void;
-  onSave: (menu: Menu) => void;
-}) {
-  const [form, setForm] = useState<Menu>({
-    name: "콜롬비아 수프리모",
-    price: 25000,
-    isSoldOut: false,
-    description: "균형잡힌 맛과 부드러운 바디감",
-    imageUrl: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/attachments/gen-images/public/colombian-coffee-beans-package-avUaPASEOeFsLXIh0tlGy3QLvNNwkP.jpg",
-  });
-
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const { name, value } = e.target;
-    setForm((prev) => ({
-      ...prev,
-      [name]: name === "price" ? +value : value,
-    }));
-  };
-
+// 최종 export
+export default function AdminPage() {
   return (
-    <div className="border rounded-lg shadow-md p-6 mb-6 bg-white">
-      <h2 className="text-xl font-semibold mb-4 text-black">새 메뉴 추가</h2>
-
-      <div className="space-y-4">
-        <input
-          type="text"
-          name="name"
-          value={form.name}
-          onChange={handleChange}
-          placeholder="메뉴 이름"
-          className="w-full border border-gray-300 p-3 rounded focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-black"
-        />
-        <input
-          type="number"
-          name="price"
-          value={form.price}
-          onChange={handleChange}
-          placeholder="가격"
-          className="w-full border border-gray-300 p-3 rounded focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-black"
-        />
-        <input
-          type="text"
-          name="description"
-          value={form.description}
-          onChange={handleChange}
-          placeholder="설명"
-          className="w-full border border-gray-300 p-3 rounded focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-black"
-        />
-        <input
-          type="text"
-          name="imageUrl"
-          value={form.imageUrl}
-          onChange={handleChange}
-          placeholder="이미지 URL"
-          className="w-full border border-gray-300 p-3 rounded focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-black"
-        />
-
-        {/* 품절 여부 토글 - 개선된 버전 */}
-        <div className="flex items-center justify-between py-2">
-          <span className="text-sm text-gray-700 font-medium">품절 여부</span>
-          <div className="flex items-center gap-3">
-            <span className="text-sm text-gray-600">
-              {form.isSoldOut ? "품절" : "판매중"}
-            </span>
-            <button
-              type="button"
-              onClick={() => setForm(prev => ({ ...prev, isSoldOut: !prev.isSoldOut }))}
-              className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 ${form.isSoldOut
-                  ? 'bg-red-500 focus:ring-red-500'
-                  : 'bg-green-500 focus:ring-green-500'
-                }`}
-            >
-              <span
-                className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform duration-200 ${form.isSoldOut ? 'translate-x-6' : 'translate-x-1'
-                  }`}
-              />
-            </button>
-          </div>
-        </div>
-      </div>
-
-      <div className="flex justify-end gap-3 mt-6">
-        <button
-          onClick={onCancel}
-          className="px-4 py-2 border border-gray-300 rounded text-gray-600 hover:bg-gray-50 transition-colors"
-        >
-          취소
-        </button>
-        <button
-          onClick={() => onSave(form)}
-          className="px-4 py-2 bg-black text-white rounded hover:bg-gray-800 transition-colors"
-        >
-          저장
-        </button>
-      </div>
-    </div>
-  );
-}
-
-//
-// 수정 폼 컴포넌트
-//
-function EditMenuForm({
-  menu,
-  onCancel,
-  onSave,
-}: {
-  menu: Menu;
-  onCancel: () => void;
-  onSave: (menu: Menu) => void;
-}) {
-  const [form, setForm] = useState<Menu>(menu);
-
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const { name, value } = e.target;
-    setForm((prev) => ({
-      ...prev,
-      [name]: name === "price" ? +value : value,
-    }));
-  };
-
-  return (
-    <div className="border rounded-lg shadow-md p-6 mb-6 bg-white">
-      <h2 className="text-xl font-semibold mb-4 text-black">메뉴 수정</h2>
-
-      <div className="space-y-4">
-        <input
-          type="text"
-          name="name"
-          value={form.name}
-          onChange={handleChange}
-          placeholder="메뉴 이름"
-          className="w-full border border-gray-300 p-3 rounded focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-black"
-        />
-        <input
-          type="number"
-          name="price"
-          value={form.price}
-          onChange={handleChange}
-          placeholder="가격"
-          className="w-full border border-gray-300 p-3 rounded focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-black"
-        />
-        <input
-          type="text"
-          name="description"
-          value={form.description}
-          onChange={handleChange}
-          placeholder="설명"
-          className="w-full border border-gray-300 p-3 rounded focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-black"
-        />
-        <input
-          type="text"
-          name="imageUrl"
-          value={form.imageUrl}
-          onChange={handleChange}
-          placeholder="이미지 URL"
-          className="w-full border border-gray-300 p-3 rounded focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-black"
-        />
-
-        {/* 품절 여부 토글 - 개선된 버전 */}
-        <div className="flex items-center justify-between py-2">
-          <span className="text-sm text-gray-700 font-medium">품절 여부</span>
-          <div className="flex items-center gap-3">
-            <span className="text-sm text-gray-600">
-              {form.isSoldOut ? "품절" : "재고있음"}
-            </span>
-            <button
-              type="button"
-              onClick={() => setForm(prev => ({ ...prev, isSoldOut: !prev.isSoldOut }))}
-              className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 ${form.isSoldOut
-                  ? 'bg-red-500 focus:ring-red-500'
-                  : 'bg-green-500 focus:ring-green-500'
-                }`}
-            >
-              <span
-                className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform duration-200 ${form.isSoldOut ? 'translate-x-6' : 'translate-x-1'
-                  }`}
-              />
-            </button>
-          </div>
-        </div>
-      </div>
-
-      <div className="flex justify-end gap-3 mt-6">
-        <button
-          onClick={onCancel}
-          className="px-4 py-2 border border-gray-300 rounded text-gray-600 hover:bg-gray-50 transition-colors"
-        >
-          취소
-        </button>
-        <button
-          onClick={() => onSave(form)}
-          className="px-4 py-2 bg-black text-white rounded hover:bg-gray-800 transition-colors"
-        >
-          저장
-        </button>
-      </div>
-    </div>
+    <AdminGuard>
+      <AdminDashboardContent />
+    </AdminGuard>
   );
 }

--- a/frontend/src/app/menu/page.tsx
+++ b/frontend/src/app/menu/page.tsx
@@ -3,23 +3,25 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { fetchApi } from "@/lib/client";
-import { useAuth } from "@/context/AuthContext"; // AuthContext 가져오기
+import { useAuth } from "@/context/AuthContext";
+import { Menu } from "@/types/menu";
 
-interface Menu {
-  menuId: number;
-  name: string;
-  price: number;
-  isSoldOut: boolean;
-  description: string;
-  imageUrl: string;
+import { MenuCard } from "@/components/menu-card";
+import AuthGuard from "@/components/auth/AuthGuard";
+
+export default function MenuPage() {
+  return (
+    <AuthGuard>
+      <MenuPageContent />
+    </AuthGuard>
+  );
 }
 
-export default function Home() {
+function MenuPageContent() {
   const [menus, setMenus] = useState<Menu[]>([]);
   const [showToast, setShowToast] = useState(false);
   const router = useRouter();
-
-  const { refetch } = useAuth(); // 전역 refetch 불러오기 (user, cartCount 갱신용)
+  const { refetch } = useAuth();
 
   // 메뉴 불러오기
   useEffect(() => {
@@ -41,9 +43,7 @@ export default function Home() {
         method: "POST",
         body: JSON.stringify({ menuId, quantity: 1 }),
       });
-
-      // 장바구니 리패치
-      await refetch();
+      await refetch(); // 장바구니 카운트 갱신
 
       // 토스트 보이기
       setShowToast(true);
@@ -62,57 +62,16 @@ export default function Home() {
       {/* 카드 리스트 */}
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 max-w-7xl w-full">
         {menus.map((menu) => (
-          <div
+          <MenuCard
             key={menu.menuId}
-            className="rounded-lg border shadow-sm overflow-hidden flex flex-col"
-          >
-            {/* 이미지 */}
-            <div className="relative">
-              <img
-                src={menu.imageUrl}
-                alt={menu.name}
-                className={`w-full h-56 object-cover ${
-                  menu.isSoldOut ? "opacity-50" : ""
-                }`}
-              />
-              {menu.isSoldOut && (
-                <span className="absolute top-2 right-2 bg-red-500 text-white text-xs px-2 py-1 rounded">
-                  품절
-                </span>
-              )}
-            </div>
-
-            {/* 내용 */}
-            <div className="p-4 flex flex-col gap-2 flex-grow">
-              <h3 className="text-black font-semibold">{menu.name}</h3>
-              <p
-                className="text-sm text-gray-400 truncate"
-                title={menu.description}
-              >
-                {menu.description}
-              </p>
-              <p className="text-black font-bold mt-auto">
-                {menu.price.toLocaleString()}원
-              </p>
-            </div>
-
-            {/* 버튼 */}
-            <button
-              disabled={menu.isSoldOut}
-              onClick={() => handleAddToCart(menu.menuId)}
-              className={`w-full py-3 font-medium ${
-                menu.isSoldOut
-                  ? "bg-gray-300 text-gray-600 cursor-not-allowed"
-                  : "bg-black text-white hover:bg-gray-800"
-              }`}
-            >
-              {menu.isSoldOut ? "품절" : "장바구니 담기"}
-            </button>
-          </div>
+            menu={menu}
+            onClick={() => handleAddToCart(menu.menuId!)}
+            buttonLabel="장바구니 담기"
+          />
         ))}
       </div>
 
-      {/* 토스트 (하단 고정) */}
+      {/* 토스트 */}
       {showToast && (
         <div className="fixed bottom-4 inset-x-0 flex justify-center">
           <div className="bg-black text-white px-4 py-3 rounded-lg shadow-lg flex items-center gap-4">

--- a/frontend/src/components/MenuCard.tsx
+++ b/frontend/src/components/MenuCard.tsx
@@ -1,0 +1,61 @@
+// src/components/MenuCard.tsx
+"use client";
+import { Menu } from "@/types/menu";
+
+export function MenuCard({
+  menu,
+  onClick,
+  disabled,
+  buttonLabel,
+}: {
+  menu: Menu;
+  onClick?: () => void;
+  disabled?: boolean;
+  buttonLabel?: string;
+}) {
+  return (
+    <div className="rounded-lg border shadow-sm overflow-hidden flex flex-col">
+      {/* 이미지 */}
+      <div className="relative">
+        <img
+          src={menu.imageUrl}
+          alt={menu.name}
+          className={`w-full h-56 object-cover ${
+            menu.isSoldOut ? "opacity-50" : ""
+          }`}
+        />
+        {menu.isSoldOut && (
+          <span className="absolute top-2 right-2 bg-red-500 text-white text-xs px-2 py-1 rounded">
+            품절
+          </span>
+        )}
+      </div>
+
+      {/* 내용 */}
+      <div className="p-4 flex flex-col gap-2 flex-grow">
+        <h3 className="text-black font-semibold">{menu.name}</h3>
+        <p className="text-sm text-gray-400 truncate" title={menu.description}>
+          {menu.description}
+        </p>
+        <p className="text-black font-bold mt-auto">
+          {menu.price.toLocaleString()}원
+        </p>
+      </div>
+
+      {/* 버튼 */}
+      {onClick && (
+        <button
+          disabled={disabled}
+          onClick={onClick}
+          className={`w-full py-3 font-medium ${
+            disabled
+              ? "bg-gray-300 text-gray-600 cursor-not-allowed"
+              : "bg-black text-white hover:bg-gray-800"
+          }`}
+        >
+          {buttonLabel || "확인"}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/admin/AdminMenuCard.tsx
+++ b/frontend/src/components/admin/AdminMenuCard.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { Menu } from "@/types/menu";
+
+import ToggleSwitch from "@/components/ui/ToggleSwitch";
+
+interface AdminMenuCardProps {
+    menu: Menu;
+    onToggleSoldOut: (menuId: number, current: boolean) => void;
+    onEdit: (menu: Menu) => void;
+    onDelete: (menuId: number) => void;
+}
+
+export default function AdminMenuCard({
+    menu,
+    onToggleSoldOut,
+    onEdit,
+    onDelete,
+}: AdminMenuCardProps) {
+    return (
+        <div className="flex items-center border rounded-lg shadow-sm p-4">
+            <img
+                src={menu.imageUrl}
+                alt={menu.name}
+                className="w-24 h-24 object-cover rounded"
+            />
+            <div className="ml-4 flex-1">
+                <h3 className="text-lg font-semibold text-black">{menu.name}</h3>
+                <p className="text-sm text-gray-600 line-clamp-2">{menu.description}</p>
+                <p className="text-md font-bold mt-1 text-black">
+                    {menu.price.toLocaleString()}원
+                </p>
+            </div>
+
+            <div className="flex gap-4 items-center">
+                {/* 품절 토글 */}
+                <ToggleSwitch
+                    checked={menu.isSoldOut} // true면 품절, false면 재고있음
+                    onChange={() => onToggleSoldOut(menu.menuId!, menu.isSoldOut)}
+                    onLabel="품절"
+                    offLabel="재고있음"
+                    onColor="bg-gray-300" // 품절일 때 (isSoldOut=true → 회색)
+                    offColor="bg-green-500" // 재고있을 때 (isSoldOut=false → 초록)
+                />
+
+
+                {/* 수정 버튼 */}
+                <button
+                    onClick={() => onEdit(menu)}
+                    className="px-3 py-1 border rounded text-black hover:bg-gray-50 transition-colors"
+                >
+                    수정
+                </button>
+
+                {/* 삭제 버튼 */}
+                <button
+                    onClick={() => onDelete(menu.menuId!)}
+                    className="px-3 py-1 border rounded text-red-500 hover:bg-red-50 transition-colors"
+                >
+                    삭제
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/components/admin/CreateMenuForm.tsx
+++ b/frontend/src/components/admin/CreateMenuForm.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useState } from "react";
+import { Menu } from "@/types/menu";
+
+import ToggleSwitch from "@/components/ui/ToggleSwitch";
+
+export default function CreateMenuForm({
+  onCancel,
+  onSave,
+}: {
+  onCancel: () => void;
+  onSave: (menu: Menu) => void;
+}) {
+  const [form, setForm] = useState<Menu>({
+    name: "",
+    price: 0,
+    isSoldOut: false,
+    description: "",
+    imageUrl: "",
+  });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setForm((prev) => ({
+      ...prev,
+      [name]: name === "price" ? +value : value,
+    }));
+  };
+
+  return (
+    <div className="border rounded-lg shadow-md p-6 mb-6 bg-white">
+      <h2 className="text-xl font-semibold mb-4 text-black">새 메뉴 추가</h2>
+
+      <div className="space-y-4">
+        <input
+          type="text"
+          name="name"
+          value={form.name}
+          onChange={handleChange}
+          placeholder="메뉴 이름"
+          className="w-full border border-gray-300 p-3 rounded text-black"
+        />
+        <input
+          type="number"
+          name="price"
+          value={form.price}
+          onChange={handleChange}
+          placeholder="가격"
+          className="w-full border border-gray-300 p-3 rounded text-black"
+        />
+        <input
+          type="text"
+          name="description"
+          value={form.description}
+          onChange={handleChange}
+          placeholder="설명"
+          className="w-full border border-gray-300 p-3 rounded text-black"
+        />
+        <input
+          type="text"
+          name="imageUrl"
+          value={form.imageUrl}
+          onChange={handleChange}
+          placeholder="이미지 URL"
+          className="w-full border border-gray-300 p-3 rounded text-black"
+        />
+
+        {/* 품절 여부 토글 */}
+        <ToggleSwitch
+          checked={form.isSoldOut}
+          onChange={() => setForm((prev) => ({ ...prev, isSoldOut: !prev.isSoldOut }))}
+          onLabel="품절"
+          offLabel="판매중"
+        />
+      </div>
+
+      <div className="flex justify-end gap-3 mt-6">
+        <button
+          onClick={onCancel}
+          className="px-4 py-2 border border-gray-300 rounded text-gray-600 hover:bg-gray-50"
+        >
+          취소
+        </button>
+        <button
+          onClick={() => onSave(form)}
+          className="px-4 py-2 bg-black text-white rounded hover:bg-gray-800"
+        >
+          저장
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/admin/EditMenuForm.tsx
+++ b/frontend/src/components/admin/EditMenuForm.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useState } from "react";
+import { Menu } from "@/types/menu";
+
+import ToggleSwitch from "@/components/ui/ToggleSwitch";
+
+export default function EditMenuForm({
+  menu,
+  onCancel,
+  onSave,
+}: {
+  menu: Menu;
+  onCancel: () => void;
+  onSave: (menu: Menu) => void;
+}) {
+  const [form, setForm] = useState<Menu>(menu);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setForm((prev) => ({
+      ...prev,
+      [name]: name === "price" ? +value : value,
+    }));
+  };
+
+  return (
+    <div className="border rounded-lg shadow-md p-6 mb-6 bg-white">
+      <h2 className="text-xl font-semibold mb-4 text-black">메뉴 수정</h2>
+
+      <div className="space-y-4">
+        <input
+          type="text"
+          name="name"
+          value={form.name}
+          onChange={handleChange}
+          placeholder="메뉴 이름"
+          className="w-full border border-gray-300 p-3 rounded text-black"
+        />
+        <input
+          type="number"
+          name="price"
+          value={form.price}
+          onChange={handleChange}
+          placeholder="가격"
+          className="w-full border border-gray-300 p-3 rounded text-black"
+        />
+        <input
+          type="text"
+          name="description"
+          value={form.description}
+          onChange={handleChange}
+          placeholder="설명"
+          className="w-full border border-gray-300 p-3 rounded text-black"
+        />
+        <input
+          type="text"
+          name="imageUrl"
+          value={form.imageUrl}
+          onChange={handleChange}
+          placeholder="이미지 URL"
+          className="w-full border border-gray-300 p-3 rounded text-black"
+        />
+
+        {/* 품절 여부 토글 */}
+        <ToggleSwitch
+          checked={form.isSoldOut}
+          onChange={() => setForm((prev) => ({ ...prev, isSoldOut: !prev.isSoldOut }))}
+          onLabel="품절"
+          offLabel="판매중"
+        />
+      </div>
+
+      <div className="flex justify-end gap-3 mt-6">
+        <button
+          onClick={onCancel}
+          className="px-4 py-2 border border-gray-300 rounded text-gray-600 hover:bg-gray-50"
+        >
+          취소
+        </button>
+        <button
+          onClick={() => onSave(form)}
+          className="px-4 py-2 bg-black text-white rounded hover:bg-gray-800"
+        >
+          저장
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/auth/AdminGuard.tsx
+++ b/frontend/src/components/auth/AdminGuard.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/context/AuthContext";
+
+interface AdminGuardProps {
+  children: React.ReactNode;
+  redirectTo?: string;
+}
+
+export default function AdminGuard({
+  children,
+  redirectTo = "/",
+}: AdminGuardProps) {
+  const { user, isLoading } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!isLoading) {
+      if (!user) {
+        router.push("/login");
+      } else if (user.level !== 0) {
+        router.push(redirectTo); // 권한 없는 경우 리다이렉트
+      }
+    }
+  }, [user, isLoading, router, redirectTo]);
+
+  if (isLoading) {
+    return <div className="p-10">관리자 인증 확인 중...</div>;
+  }
+
+  if (!user || user.level !== 0) {
+    return null;
+  }
+
+  return <>{children}</>;
+}

--- a/frontend/src/components/ui/ToggleSwitch.tsx
+++ b/frontend/src/components/ui/ToggleSwitch.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+interface ToggleSwitchProps {
+  checked: boolean; // true = 재고있음, false = 품절
+  onChange: () => void;
+  onLabel?: string;
+  offLabel?: string;
+  onColor?: string;
+  offColor?: string;
+}
+
+export default function ToggleSwitch({
+  checked,
+  onChange,
+  onLabel = "재고있음",  // true일 때
+  offLabel = "품절",     // false일 때
+  onColor = "bg-green-500",
+  offColor = "bg-gray-300",
+}: ToggleSwitchProps) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-sm text-gray-600">
+        {checked ? onLabel : offLabel}
+      </span>
+      <button
+        type="button"
+        onClick={onChange}
+        className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 ${
+          checked ? onColor : offColor
+        }`}
+      >
+        <span
+          className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform duration-200 ${
+            checked ? "translate-x-6" : "translate-x-1"
+          }`}
+        />
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/types/menu.ts
+++ b/frontend/src/types/menu.ts
@@ -1,0 +1,10 @@
+// src/types/menu.ts
+
+export interface Menu {
+    menuId?: number;
+    name: string;
+    price: number;
+    isSoldOut: boolean;
+    description: string;
+    imageUrl: string;
+  }  


### PR DESCRIPTION
## #️⃣ 연관된 이슈 <!-- 이슈 번호를 적어주세요 -->
#179 
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
관리자(Admin)와 메뉴(Menu) 관련 컴포넌트 및 타입을 분리하여 구조를 개선했습니다.
중복되거나 한 파일에 몰려 있던 로직을 정리해 관리성을 높이고, Menu 타입을 공통으로 사용할 수 있도록 types 디렉토리로 분리했습니다.
또한 재사용 가능한 컴포넌트(MenuCard, ToggleSwitch)를 별도 파일로 분리하여 다른 화면에서도 쉽게 활용할 수 있도록 리팩토링했습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- Menu 타입을 src/types/menu.ts로 분리
- 관리자(Admin) 관련 컴포넌트 모듈화
- AdminMenuCard 분리
- CreateMenuForm 분리
- EditMenuForm 분리
- 사용자(Menu) 페이지에서 공통 MenuCard 사용하도록 변경
- ToggleSwitch를 공통 컴포넌트로 분리
- menu 페이지에서 admin과 동일한 Menu 타입 사용하도록 수정

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
