### PR TITLE
refactor(payment): 장바구니 아이콘 refetch, 배송 주소, 결제 금액 UI, 로그인 접근

### DIFF
--- a/backend/src/main/java/com/backend/domain/payment/service/RandomPaymentProcessor.java
+++ b/backend/src/main/java/com/backend/domain/payment/service/RandomPaymentProcessor.java
@@ -8,8 +8,8 @@ public class RandomPaymentProcessor implements PaymentProcessor {
     @Override
     public boolean process(PaymentCreateRequest request) {
         /*
-         * 결제 실패 시뮬레이션: 70% 성공률
+         * 결제 실패 시뮬레이션: 50% 성공률
          */
-        return Math.random() > 0.3;
+        return Math.random() > 0.5;
     }
 }

--- a/frontend/src/app/payment/fail/page.tsx
+++ b/frontend/src/app/payment/fail/page.tsx
@@ -13,7 +13,7 @@ export default function PaymentFailPage() {
       await refetch();
     }
     fetchData();
-  }, [refetch])
+  }, [])
 
   return (
     <div className="min-h-screen bg-gray-50">

--- a/frontend/src/app/payment/fail/page.tsx
+++ b/frontend/src/app/payment/fail/page.tsx
@@ -1,10 +1,19 @@
-// src/app/payment/fail/page.tsx
 "use client"
 
+import { useAuth } from "@/context/AuthContext"; 
 import { useRouter } from "next/navigation"
+import { useEffect } from "react"
 
 export default function PaymentFailPage() {
+  const { refetch } = useAuth();
   const router = useRouter()
+
+  useEffect(() => {
+    async function fetchData() {
+      await refetch();
+    }
+    fetchData();
+  }, [refetch])
 
   return (
     <div className="min-h-screen bg-gray-50">

--- a/frontend/src/app/payment/fail/page.tsx
+++ b/frontend/src/app/payment/fail/page.tsx
@@ -3,8 +3,18 @@
 import { useAuth } from "@/context/AuthContext"; 
 import { useRouter } from "next/navigation"
 import { useEffect } from "react"
+import AuthGuard from "@/components/auth/AuthGuard";
 
-export default function PaymentFailPage() {
+// ✅ 변경점: AuthGuard 사용하여 로그인 상태 처리
+export default function CartPage() {
+  return (
+    <AuthGuard>
+      <PaymentFailPage />
+    </AuthGuard>
+  );
+}
+
+function PaymentFailPage() {
   const { refetch } = useAuth();
   const router = useRouter()
 

--- a/frontend/src/app/payment/page.tsx
+++ b/frontend/src/app/payment/page.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from "react"
 import { useRouter } from "next/navigation"
 import { fetchApi } from "@/lib/client"
 import Link from "next/link"
+import AuthGuard from "@/components/auth/AuthGuard";
 
 type Address = {
   addressId: number
@@ -36,7 +37,16 @@ type CartResponse = {
   grandTotal: number
 }
 
-export default function CheckoutPage() {
+// ✅ 변경점: AuthGuard 사용하여 로그인 상태 처리
+export default function CartPage() {
+  return (
+    <AuthGuard>
+      <CheckoutPage />
+    </AuthGuard>
+  );
+}
+
+function CheckoutPage() {
   const router = useRouter()
 
   const [addresses, setAddresses] = useState<Address[]>([])

--- a/frontend/src/app/payment/page.tsx
+++ b/frontend/src/app/payment/page.tsx
@@ -1,6 +1,7 @@
 // src/app/payment/page.tsx
 "use client"
 
+import { useAuth } from "@/context/AuthContext";
 import { useEffect, useState } from "react"
 import { useRouter } from "next/navigation"
 import { fetchApi } from "@/lib/client"
@@ -43,7 +44,8 @@ export default function CheckoutPage() {
   const [user, setUser] = useState<User | null>(null)
 
   const [cart, setCart] = useState<CartResponse | null>(null)
-
+  const { refetch } = useAuth();
+  
   // 초기 데이터 불러오기
   useEffect(() => {
     async function loadData() {
@@ -122,6 +124,7 @@ export default function CheckoutPage() {
 
       // 3. 주문 성공 페이지로로 이동
       router.push(`/payment/success?orderId=${orderId}`)
+      await refetch();
     } catch (err) {
       console.error("주문/결제 실패:", err)
       router.push(`/payment/fail`)
@@ -163,7 +166,7 @@ export default function CheckoutPage() {
                   <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
                   </svg>
-                  주소 등록하러 가기기
+                  주소 등록하러 가기
                 </button>
               </Link>
             </ul>

--- a/frontend/src/app/payment/success/page.tsx
+++ b/frontend/src/app/payment/success/page.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useAuth } from "@/context/AuthContext"; 
 import { useEffect, useState } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
 import { fetchApi } from "@/lib/client"
@@ -30,6 +31,7 @@ interface ApiResponse<T> {
 }
 
 export default function OrderSuccessPage() {
+  const { refetch } = useAuth();
   const router = useRouter()
   const searchParams = useSearchParams()
   const orderId = searchParams.get('orderId')
@@ -43,6 +45,8 @@ export default function OrderSuccessPage() {
       try {
         setLoading(true)
         setError(null)
+        
+        await refetch();
 
         const res = await fetchApi(`/api/orders/${orderId}`, { method: "GET" })
         setOrder(res.data)


### PR DESCRIPTION
## #️⃣ 연관된 이슈 <!-- 이슈 번호를 적어주세요 -->
#180 

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
주문 완료 페이지 - 장바구니 아이콘 refetch, 배송 주소, 결제 금액 UI, 로그인 접근 관련 수정

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
6290e2a: 결제 성공률 50%로 하향 조정했습니다
5abb714: 주문 생성 시 장바구니 아이콘이 비워지도록 refetch 설정했습니다
207b680: 주문 완료 페이지에 배송 주소가 상세 주소만 뜨던 점과 배송비 확인 가능하게끔 UI 수정했습니다
00e3cd0: 로그인하지 않으면 payment 관련 도메인에 접근 불가하도록 수정했습니다

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
5abb714: 주문 생성 시 장바구니 아이콘이 비워지도록 refetch 설정했습니다
207b680: 주문 완료 페이지에 배송 주소가 상세 주소만 뜨던 점과 배송비 확인 가능하게끔 UI 수정했습니다

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
