### PR TITLE
feat:[FE] 관리자 주문 조회 페이지 리펙토링 및 약간의 색상 변경

### DIFF
--- a/frontend/src/app/orders/admin/page.tsx
+++ b/frontend/src/app/orders/admin/page.tsx
@@ -3,7 +3,8 @@
 import { useEffect, useState } from "react"
 import { fetchApi } from "@/lib/client"
 import { OrderItem,AdminOrder } from "@/types/order"
-import Link from "next/link"
+import { AdminOrderCardEmptyState } from "@/components/admin-order-card";
+import { AdminOrderCard } from "@/components/admin-order-card";
 
 export default function AdminOrdersPage() {
   const [orders, setOrders] = useState<AdminOrder[]>([])
@@ -47,107 +48,15 @@ export default function AdminOrdersPage() {
         <h1 className="text-2xl font-bold mb-6">관리자 주문 관리</h1>
 
         {orders.length === 0 ? (
-          <div className="text-center py-16">
-            <h2 className="text-2xl font-bold mb-2">주문내역이 없습니다</h2>
-            <p className="text-gray-500 mb-6">아직 들어온 주문이 없습니다.</p>
-          </div>
+          <AdminOrderCardEmptyState />
         ) : (
           <div className="space-y-6">
             {orders.map((order) => (
-              <div
+              <AdminOrderCard
                 key={order.orderId}
-                className="bg-white border rounded-lg shadow-sm p-6"
-              >
-                {/* 상단 */}
-                <div className="flex justify-between items-center mb-2">
-                  <h2 className="font-bold text-lg">
-                    주문번호 #{order.orderId}
-                  </h2>
-                  <span
-                    className={`text-sm px-2 py-0.5 rounded ${
-                      order.status === "PAID"
-                        ? "bg-blue-100 text-blue-600"
-                        : order.status === "COMPLETED"
-                        ? "bg-green-100 text-green-600"
-                        : "bg-gray-100 text-gray-600"
-                    }`}
-                  >
-                    {order.status}
-                  </span>
-                </div>
-
-                {/* 메타 정보 */}
-                <p className="text-sm text-gray-500 mb-2">
-                  주문일시: {new Date(order.orderTime).toLocaleString()}
-                </p>
-                <p className="font-semibold mb-2">
-                  총 금액: {order.orderAmount.toLocaleString()}원
-                </p>
-                <p className="text-sm text-gray-600">주소: {order.address}</p>
-                <p className="text-sm text-gray-600">
-                  사용자: {order.userEmail} ({order.userPhone})
-                </p>
-
-                {/* 상품 */}
-                <ul className="mt-2 text-sm text-gray-700 space-y-2">
-                  {order.items.map((item, idx) => (
-                    <li
-                      key={idx}
-                      className="flex items-center gap-3 border-b pb-2"
-                    >
-                      {/* 이미지 */}
-                      {item.imageUrl && (
-                        <img
-                          src={item.imageUrl}
-                          alt={item.productName}
-                          className="w-12 h-12 object-cover rounded"
-                        />
-                      )}
-                      {/* 상품명 + 수량 */}
-                      <div className="flex-1">
-                        <span className="font-medium">{item.productName}</span>{" "}
-                        <span className="text-gray-500">
-                          ({item.quantity}개)
-                        </span>
-                      </div>
-                      {/* 금액 */}
-                      <span className="font-semibold">
-                        {item.orderPrice.toLocaleString()}원
-                      </span>
-                    </li>
-                  ))}
-                </ul>
-
-                {/* 버튼 */}
-                <div className="flex gap-2 mt-4">
-                  {/* 결제 내역 보기 */}
-                  {order.paymentId ? (
-                    <Link
-                      href={`/payment/${order.paymentId}`}
-                      className="flex-1"
-                    >
-                      <button className="w-full border rounded py-2 text-sm bg-blue-50 hover:bg-blue-100 text-center">
-                        결제 내역 보기
-                      </button>
-                    </Link>
-                  ) : (
-                    <button
-                      disabled
-                      className="flex-1 w-full border rounded py-2 text-sm bg-gray-200 text-gray-400 cursor-not-allowed"
-                    >
-                      결제 내역 없음
-                    </button>
-                  )}
-
-                  {/* 배송 처리 */}
-                  <button
-                    onClick={() => updateStatus(order.orderId, "COMPLETED")}
-                    className="flex-1 border rounded py-2 text-sm bg-green-50 hover:bg-green-100"
-                  >
-                    배송 처리(COMPLETED)
-                  </button>
-                </div>
-              </div>
+                order={order}
+                onUpdateStatus={updateStatus}
+              />
             ))}
           </div>
         )}

--- a/frontend/src/app/orders/page.tsx
+++ b/frontend/src/app/orders/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react"
 import Link from "next/link"
 import { fetchApi } from "@/lib/client"
 import { Order, OrderItem, ORDER_STATUS } from "@/types/order";
-import { OrderItemCard , EmptyOrderState} from "@/components/order/order-item";
+import { OrderItemCard , EmptyOrderState} from "@/components/order-item";
 
 
 export default function OrdersPage() {

--- a/frontend/src/components/admin-order-card.tsx
+++ b/frontend/src/components/admin-order-card.tsx
@@ -1,0 +1,111 @@
+"use client"
+
+import Link from "next/link"
+import { AdminOrder } from "@/types/order"
+
+interface Props {
+  order: AdminOrder
+  onUpdateStatus: (orderId: number, newStatus: string) => void
+}
+
+// ✅ 상태별 텍스트 + 색상 클래스 (OrderItemCard와 동일한 border 스타일 적용)
+const getStatusInfo = (status: string) => {
+  const statusMap: Record<
+    string,
+    { text: string; className: string }
+  > = {
+    CREATED: { text: "결제 실패", className: "text-red-600 border-red-600" },
+    PAID: { text: "결제 완료", className: "text-blue-600 border-blue-600" },
+    COMPLETED: { text: "배송 완료", className: "text-gray-600 border-gray-400" },
+    CANCELED: { text: "주문 취소", className: "text-red-600 border-red-600" },
+  }
+  return statusMap[status] || { text: status, className: "text-gray-600 border-gray-400" }
+}
+
+export function AdminOrderCard({ order, onUpdateStatus }: Props) {
+  const statusInfo = getStatusInfo(order.status)
+
+  return (
+    <div className="bg-white border rounded-lg shadow-sm p-6">
+      {/* 상단 */}
+      <div className="flex justify-between items-center mb-2">
+        <h2 className="font-bold text-lg">주문번호 #{order.orderId}</h2>
+        <span
+          className={`text-sm border px-2 py-0.5 rounded ${statusInfo.className}`}
+        >
+          {statusInfo.text}
+        </span>
+      </div>
+
+      {/* 메타 정보 */}
+      <p className="text-sm text-gray-500 mb-2">
+        주문일시: {new Date(order.orderTime).toLocaleString()}
+      </p>
+      <p className="font-semibold mb-2">
+        총 금액: {order.orderAmount.toLocaleString()}원
+      </p>
+      <p className="text-sm text-gray-600">주소: {order.address}</p>
+      <p className="text-sm text-gray-600">
+        사용자: {order.userEmail} ({order.userPhone})
+      </p>
+
+      {/* 상품 */}
+      <ul className="mt-2 text-sm text-gray-700 space-y-2">
+        {order.items.map((item, idx) => (
+          <li key={idx} className="flex items-center gap-3 border-b pb-2">
+            {item.imageUrl && (
+              <img
+                src={item.imageUrl}
+                alt={item.productName}
+                className="w-12 h-12 object-cover rounded"
+              />
+            )}
+            <div className="flex-1">
+              <span className="font-medium">{item.productName}</span>{" "}
+              <span className="text-gray-500">({item.quantity}개)</span>
+            </div>
+            <span className="font-semibold">
+              {item.orderPrice.toLocaleString()}원
+            </span>
+          </li>
+        ))}
+      </ul>
+
+      {/* 버튼 */}
+      <div className="flex gap-2 mt-4">
+        {/* 결제 내역 */}
+        {order.paymentId ? (
+          <Link href={`/payment/${order.paymentId}`} className="flex-1">
+            <button className="w-full border rounded py-2 text-sm bg-blue-50 hover:bg-blue-100 text-center">
+              결제 내역 보기
+            </button>
+          </Link>
+        ) : (
+          <button
+            disabled
+            className="flex-1 w-full border rounded py-2 text-sm bg-gray-200 text-gray-400 cursor-not-allowed"
+          >
+            결제 내역 없음
+          </button>
+        )}
+
+        {/* 배송 처리 */}
+        <button
+          onClick={() => onUpdateStatus(order.orderId, "COMPLETED")}
+          className="flex-1 border rounded py-2 text-sm bg-green-50 hover:bg-green-100"
+        >
+          배송 처리(COMPLETED)
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export function AdminOrderCardEmptyState() {
+  return (
+    <div className="text-center py-16">
+      <h2 className="text-2xl font-bold mb-2">주문내역이 없습니다</h2>
+      <p className="text-gray-500 mb-6">아직 들어온 주문이 없습니다.</p>
+    </div>
+  )
+}

--- a/frontend/src/components/order-item.tsx
+++ b/frontend/src/components/order-item.tsx
@@ -1,36 +1,29 @@
 "use client"
 
 import Link from "next/link"
-import { Order, ORDER_STATUS,OrderItemCardProps } from "@/types/order"
+import { Order, ORDER_STATUS, OrderItemCardProps } from "@/types/order"
+
+// ✅ 상태별 텍스트 + 색상 클래스 (AdminOrderCard 기준으로 통일)
+const getStatusInfo = (status: string) => {
+  const statusMap: Record<string, { text: string; className: string }> = {
+    CREATED: { text: "결제 실패", className: "bg-red-50 text-red-600" },
+    PAID: { text: "결제 완료", className: "bg-blue-50 text-blue-600" },
+    COMPLETED: { text: "배송 완료", className: "bg-gray-200 text-gray-600" },
+    CANCELED: { text: "주문 취소", className: "bg-red-50 text-red-600" },
+  }
+  return statusMap[status] || { text: status, className: "bg-gray-200 text-gray-600" }
+}
 
 export function OrderItemCard({ order, onCancel, onDelete }: OrderItemCardProps) {
-  // 상태 텍스트 변환
-  const getStatusText = (status: string) => {
-    const statusMap: Record<string, string> = {
-      CREATED: "결제 실패",
-      PAID: "결제 완료",
-      COMPLETED: "배송 완료",
-      CANCELED: "주문 취소",
-    }
-    return statusMap[status] || status
-  }
-
-  // 상태별 색상 클래스
-  const statusClass =
-    order.status === ORDER_STATUS.CANCELED
-      ? "text-red-600 border-red-600"
-      : order.status === ORDER_STATUS.CREATED
-      ? "text-red-600 border-red-600"
-      : order.status === ORDER_STATUS.COMPLETED
-      ? "text-gray-600 border-gray-400"
-      : "text-green-600 border-green-600"
+  const statusInfo = getStatusInfo(order.status)
 
   return (
     <div className="bg-white border rounded-lg shadow-sm p-6">
+      {/* 상단 */}
       <div className="flex justify-between items-center mb-2">
         <h2 className="font-bold text-lg">주문번호 #{order.orderId}</h2>
-        <span className={`text-sm border px-2 py-0.5 rounded ${statusClass}`}>
-          {getStatusText(order.status)}
+        <span className={`text-sm px-2 py-0.5 rounded ${statusInfo.className}`}>
+          {statusInfo.text}
         </span>
       </div>
 
@@ -42,9 +35,13 @@ export function OrderItemCard({ order, onCancel, onDelete }: OrderItemCardProps)
       </p>
       <p className="text-sm text-gray-600 mb-4">배송주소: {order.address}</p>
 
+      {/* 상품 리스트 */}
       <ul className="mt-2 text-sm text-gray-600 space-y-3">
         {order.items.map((item, idx) => (
-          <li key={`${order.orderId}-${idx}`} className="flex items-center gap-4 py-2 border-b">
+          <li
+            key={`${order.orderId}-${idx}`}
+            className="flex items-center gap-4 py-2 border-b"
+          >
             <img
               src={item.imageUrl}
               alt={item.productName}
@@ -87,9 +84,10 @@ export function OrderItemCard({ order, onCancel, onDelete }: OrderItemCardProps)
           <button
             disabled={order.status === ORDER_STATUS.COMPLETED}
             className={`flex-1 w-full border rounded py-2 text-sm text-center
-              ${order.status === ORDER_STATUS.COMPLETED
-                ? "bg-gray-200 text-gray-400 cursor-not-allowed"
-                : "bg-red-50 hover:bg-red-100 text-red-600"
+              ${
+                order.status === ORDER_STATUS.COMPLETED
+                  ? "bg-gray-200 text-gray-400 cursor-not-allowed"
+                  : "bg-red-50 hover:bg-red-100 text-red-600"
               }`}
             onClick={() => onCancel(order.orderId)}
           >


### PR DESCRIPTION
## #️⃣ 연관된 이슈 <!-- 이슈 번호를 적어주세요 -->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
관리자 주문 조회 페이지 컴포넌트 분리했습니다.
색상도 약간 수정해서 
결제 실패: 빨간색,
결제 완료: 파란색,
배송 완료: 회색,
주문 취소: 빨간색 으로 표시되게 바꿨습니다!

