### PR TITLE
fix: 토글 버튼 오류 수정, 품절 처리 시 장바구니 담기 버튼 비활성화

### DIFF
--- a/frontend/src/components/MenuCard.tsx
+++ b/frontend/src/components/MenuCard.tsx
@@ -20,9 +20,8 @@ export function MenuCard({
         <img
           src={menu.imageUrl}
           alt={menu.name}
-          className={`w-full h-56 object-cover ${
-            menu.isSoldOut ? "opacity-50" : ""
-          }`}
+          className={`w-full h-56 object-cover ${menu.isSoldOut ? "opacity-50" : ""
+            }`}
         />
         {menu.isSoldOut && (
           <span className="absolute top-2 right-2 bg-red-500 text-white text-xs px-2 py-1 rounded">
@@ -45,18 +44,17 @@ export function MenuCard({
       {/* 버튼 */}
       {onClick && (
         <button
-          disabled={disabled}
+          disabled={disabled || menu.isSoldOut} // 품절이면 버튼 비활성화
           onClick={() => {
             console.log("👉 버튼 클릭됨:", menu.menuId);
             onClick?.();
           }}
-          className={`w-full py-3 font-medium ${
-            disabled
+          className={`w-full py-3 font-medium ${disabled || menu.isSoldOut
               ? "bg-gray-300 text-gray-600 cursor-not-allowed"
               : "bg-black text-white hover:bg-gray-800"
-          }`}
+            }`}
         >
-          {buttonLabel || "확인"}
+          {menu.isSoldOut ? "품절" : buttonLabel || "확인"}
         </button>
       )}
     </div>

--- a/frontend/src/components/admin/AdminMenuCard.tsx
+++ b/frontend/src/components/admin/AdminMenuCard.tsx
@@ -35,12 +35,12 @@ export default function AdminMenuCard({
             <div className="flex gap-4 items-center">
                 {/* 품절 토글 */}
                 <ToggleSwitch
-                    checked={menu.isSoldOut} // true면 품절, false면 재고있음
+                    checked={!menu.isSoldOut} // 판매중일 때 ON
                     onChange={() => onToggleSoldOut(menu.menuId!, menu.isSoldOut)}
-                    onLabel="품절"
-                    offLabel="재고있음"
-                    onColor="bg-gray-300" // 품절일 때 (isSoldOut=true → 회색)
-                    offColor="bg-green-500" // 재고있을 때 (isSoldOut=false → 초록)
+                    onLabel="판매중"
+                    offLabel="품절"
+                    onColor="bg-green-500"
+                    offColor="bg-gray-300"
                 />
 
 

--- a/frontend/src/components/admin/CreateMenuForm.tsx
+++ b/frontend/src/components/admin/CreateMenuForm.tsx
@@ -13,11 +13,11 @@ export default function CreateMenuForm({
   onSave: (menu: Menu) => void;
 }) {
   const [form, setForm] = useState<Menu>({
-    name: "",
-    price: 0,
+    name: "새로운 메뉴",
+    price: 20000,
     isSoldOut: false,
-    description: "",
-    imageUrl: "",
+    description: "부드러운 바디감과 고소한 견과류 향의 대표적인 원두",
+    imageUrl: "https://i.postimg.cc/JGY04s7v/colombia.jpg",
   });
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -68,10 +68,12 @@ export default function CreateMenuForm({
 
         {/* 품절 여부 토글 */}
         <ToggleSwitch
-          checked={form.isSoldOut}
+          checked={!form.isSoldOut} // 판매중일 때 ON
           onChange={() => setForm((prev) => ({ ...prev, isSoldOut: !prev.isSoldOut }))}
-          onLabel="품절"
-          offLabel="판매중"
+          onLabel="판매중"
+          offLabel="품절"
+          onColor="bg-green-500"
+          offColor="bg-gray-300"
         />
       </div>
 

--- a/frontend/src/components/admin/EditMenuForm.tsx
+++ b/frontend/src/components/admin/EditMenuForm.tsx
@@ -64,10 +64,12 @@ export default function EditMenuForm({
 
         {/* 품절 여부 토글 */}
         <ToggleSwitch
-          checked={form.isSoldOut}
+          checked={!form.isSoldOut} // 판매중일 때 ON
           onChange={() => setForm((prev) => ({ ...prev, isSoldOut: !prev.isSoldOut }))}
-          onLabel="품절"
-          offLabel="판매중"
+          onLabel="판매중"
+          offLabel="품절"
+          onColor="bg-green-500"
+          offColor="bg-gray-300"
         />
       </div>
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈 <!-- 이슈 번호를 적어주세요 -->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
메뉴 품절 상태 토글 시 UI 표시가 반대로 나타나는 문제를 수정하였고,
품절된 메뉴임에도 장바구니 담기 버튼이 활성화되어 있던 오류를 해결했습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- ToggleSwitch 컴포넌트 및 CreateMenuForm, AdminMenuCard에서 isSoldOut 상태와 표시 라벨/색상을 일관되게 맞춤
- MenuCard에서 menu.isSoldOut === true일 경우 장바구니 담기 버튼이 비활성화되도록 로직 수정
- 버튼 라벨을 "품절"로 표시하여 사용자 혼란 방지

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
